### PR TITLE
Install git in builder image

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,6 +1,8 @@
 ARG RUBY_MAJOR
 FROM ghcr.io/alphagov/govuk-ruby-base:${RUBY_MAJOR}
 
+RUN install_packages git
+
 # Environment variables to make build cleaner and faster
 ENV BUNDLE_IGNORE_MESSAGES=1 \
   BUNDLE_SILENCE_ROOT_WARNING=1 \


### PR DESCRIPTION
Publisher requires it. It may as well be in the builder image in case anything else requires it too