### PR TITLE
Include tzdata package in base images

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -81,10 +81,12 @@ ENV GEM_HOME=/usr/local/bundle \
 	BUNDLE_WITHOUT="development test" \
 	GOVUK_APP_DOMAIN=www.gov.uk \
 	GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-	GOVUK_PROMETHEUS_EXPORTER=true
+	GOVUK_PROMETHEUS_EXPORTER=true \
+	DEBIAN_FRONTEND=noninteractive \
+	TZ=Europe/London
 
-# Install node.js and yarn
-RUN install_packages ca-certificates curl gpg build-essential default-libmysqlclient-dev && \
+# Install node.js, yarn and other runtime dependencies
+RUN install_packages ca-certificates curl gpg build-essential default-libmysqlclient-dev tzdata && \
 	curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "/usr/share/keyrings/nodesource.gpg" >/dev/null && \
 	echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x jammy main" | tee /etc/apt/sources.list.d/nodesource.list && \
 	install_packages nodejs && npm i -g yarn


### PR DESCRIPTION
Minideb included timezone data, whereas the ubuntu image does not. The data is required for a lot of ruby apps to work, so we should install it in the base image.