### PR TITLE
libpq-dev is needed in the builder images and libpq5 in the base image.

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -86,7 +86,7 @@ ENV GEM_HOME=/usr/local/bundle \
 	TZ=Europe/London
 
 # Install node.js, yarn and other runtime dependencies
-RUN install_packages ca-certificates curl gpg build-essential default-libmysqlclient-dev tzdata libpq-dev && \
+RUN install_packages ca-certificates curl gpg build-essential default-libmysqlclient-dev tzdata libpq5 && \
 	curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "/usr/share/keyrings/nodesource.gpg" >/dev/null && \
 	echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x jammy main" | tee /etc/apt/sources.list.d/nodesource.list && \
 	install_packages nodejs && npm i -g yarn

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,7 +1,7 @@
 ARG RUBY_MAJOR
 FROM ghcr.io/alphagov/govuk-ruby-base:${RUBY_MAJOR}
 
-RUN install_packages git
+RUN install_packages git libpq-dev
 
 # Environment variables to make build cleaner and faster
 ENV BUNDLE_IGNORE_MESSAGES=1 \


### PR DESCRIPTION
Some apps require this - example app is service-manual-publisher