### PR TITLE
Create /app/tmp symlink in base image + minor improvements.

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -11,55 +11,55 @@ RUN : "${RUBY_MAJOR?}" "${RUBY_VERSION?}" "${RUBY_DOWNLOAD_SHA256?}"
 
 # Set environment variables required for build
 ENV LANG=C.UTF-8 \
-  RUBY_MAJOR=${RUBY_MAJOR} \
-  RUBY_VERSION=${RUBY_VERSION} \
-  RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256} \
-  MAKEFLAGS=-j"$(nproc)"
+    RUBY_MAJOR=${RUBY_MAJOR} \
+    RUBY_VERSION=${RUBY_VERSION} \
+    RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256} \
+    MAKEFLAGS=-j"$(nproc)"
 
 # Install build dependencies
 RUN install_packages build-essential bison dpkg-dev libgdbm-dev ruby wget autoconf zlib1g-dev libreadline-dev checkinstall
 
 # TODO: stop building OpenSSL once all apps are on Ruby 3.1+.
 RUN set -eux; \
-	wget -O openssl.tar.gz "https://www.openssl.org/source/openssl-1.1.1q.tar.gz"; \
-	echo "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca openssl.tar.gz" | sha256sum --check; \
-	mkdir -p /usr/src/openssl; \
-	tar -xf openssl.tar.gz -C /usr/src/openssl --strip-components=1; \
-	cd /usr/src/openssl; \
-	./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib; \
-	make; \
-	make install_sw;  # Avoid building manpages and such.
+    wget -O openssl.tar.gz "https://www.openssl.org/source/openssl-1.1.1q.tar.gz"; \
+    echo "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca openssl.tar.gz" | sha256sum --check; \
+    mkdir -p /usr/src/openssl; \
+    tar -xf openssl.tar.gz -C /usr/src/openssl --strip-components=1; \
+    cd /usr/src/openssl; \
+    ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib; \
+    make; \
+    make install_sw;  # Avoid building manpages and such.
 
 # Build Ruby
 RUN set -eux; \
-	\
-	wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR}/ruby-${RUBY_VERSION}.tar.xz"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
-	\
-	mkdir -p /usr/src/ruby /build; \
-	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \
-	rm ruby.tar.xz; \
-	\
-	cd /usr/src/ruby; \
-	\
-	{ \
-		echo '#define ENABLE_PATH_CHECK 0'; \
-		echo; \
-		cat file.c; \
-	} > file.c.new; \
-	mv file.c.new file.c; \
-	\
-	autoconf; \
-	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
-	./configure \
-		--build="$gnuArch" \
-		--disable-install-doc \
-		--enable-shared \
-    --with-destdir=/build \
-		--with-openssl-dir=/opt/openssl \
-	; \
-	make -j "$(nproc)"; \
-	make install;
+    \
+    wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR}/ruby-${RUBY_VERSION}.tar.xz"; \
+    echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+    \
+    mkdir -p /usr/src/ruby /build; \
+    tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \
+    rm ruby.tar.xz; \
+    \
+    cd /usr/src/ruby; \
+    \
+    { \
+      echo '#define ENABLE_PATH_CHECK 0'; \
+      echo; \
+      cat file.c; \
+    } > file.c.new; \
+    mv file.c.new file.c; \
+    \
+    autoconf; \
+    gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+    ./configure \
+      --build="$gnuArch" \
+      --disable-install-doc \
+      --enable-shared \
+      --with-destdir=/build \
+      --with-openssl-dir=/opt/openssl \
+    ; \
+    make -j "$(nproc)"; \
+    make install;
 
 
 FROM public.ecr.aws/lts/ubuntu:22.04_stable
@@ -73,36 +73,36 @@ COPY --from=builder /build /
 # Copy OpenSSL and link in system castore
 COPY --from=builder /opt/openssl /opt/openssl
 RUN rmdir /opt/openssl/certs; \
-	ln -s /etc/ssl/certs /opt/openssl/certs
+    ln -s /etc/ssl/certs /opt/openssl/certs
 
 # Set common environment variables
 ENV APP_HOME=/app \
-	GEM_HOME=/usr/local/bundle \
-	BUNDLE_APP_CONFIG=/usr/local/bundle \
-	BUNDLE_PATH=/usr/local/bundle \
-	BUNDLE_BIN=/usr/local/bundle/bin \
-	PATH=/usr/local/bundle/bin:$PATH \
-	IRBRC=/etc/irb.rc \
-	RAILS_LOG_TO_STDOUT=1 \
-	RAILS_ENV=production \
-	NODE_ENV=production \
-	BUNDLE_WITHOUT="development test cucumber" \
-	BOOTSNAP_CACHE_DIR=/var/cache/bootsnap \
-	GOVUK_APP_DOMAIN=www.gov.uk \
-	GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-	GOVUK_PROMETHEUS_EXPORTER=true \
-	DEBIAN_FRONTEND=noninteractive \
-	TZ=Europe/London
+    GEM_HOME=/usr/local/bundle \
+    BUNDLE_APP_CONFIG=/usr/local/bundle \
+    BUNDLE_PATH=/usr/local/bundle \
+    BUNDLE_BIN=/usr/local/bundle/bin \
+    PATH=/usr/local/bundle/bin:$PATH \
+    IRBRC=/etc/irb.rc \
+    RAILS_LOG_TO_STDOUT=1 \
+    RAILS_ENV=production \
+    NODE_ENV=production \
+    BUNDLE_WITHOUT="development test cucumber" \
+    BOOTSNAP_CACHE_DIR=/var/cache/bootsnap \
+    GOVUK_APP_DOMAIN=www.gov.uk \
+    GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+    GOVUK_PROMETHEUS_EXPORTER=true \
+    DEBIAN_FRONTEND=noninteractive \
+    TZ=Europe/London
 
 # Install node.js, yarn and other runtime dependencies
 RUN install_packages ca-certificates curl gpg default-libmysqlclient-dev tzdata libpq5 && \
-	curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "/usr/share/keyrings/nodesource.gpg" >/dev/null && \
-	echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x jammy main" | tee /etc/apt/sources.list.d/nodesource.list && \
-	install_packages nodejs && npm i -g yarn
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "/usr/share/keyrings/nodesource.gpg" >/dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x jammy main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    install_packages nodejs && npm i -g yarn
 
 # Add app user
 RUN groupadd -g 1001 app && \
-	useradd -u 1001 -g app app --home $APP_HOME
+    useradd -u 1001 -g app app --home $APP_HOME
 
 # Some Rubygems (libraries) assume that they can write to tmp/ within the Rails
 # app's base directory.

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,4 +1,5 @@
 FROM public.ecr.aws/lts/ubuntu:22.04_stable AS builder
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Copy helper script for package installation
 COPY install_packages.sh /usr/sbin/install_packages

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -76,12 +76,17 @@ RUN rmdir /opt/openssl/certs; \
 	ln -s /etc/ssl/certs /opt/openssl/certs
 
 # Set common environment variables
-ENV GEM_HOME=/usr/local/bundle \
+ENV APP_HOME=/app \
+	GEM_HOME=/usr/local/bundle \
 	BUNDLE_APP_CONFIG=/usr/local/bundle \
+	BUNDLE_PATH=/usr/local/bundle \
+	BUNDLE_BIN=/usr/local/bundle/bin \
+	PATH=/usr/local/bundle/bin:$PATH \
 	RAILS_LOG_TO_STDOUT=1 \
 	RAILS_ENV=production \
 	NODE_ENV=production \
-	BUNDLE_WITHOUT="development test" \
+	BUNDLE_WITHOUT="development test cucumber" \
+	BOOTSNAP_CACHE_DIR=/var/cache/bootsnap \
 	GOVUK_APP_DOMAIN=www.gov.uk \
 	GOVUK_WEBSITE_ROOT=https://www.gov.uk \
 	GOVUK_PROMETHEUS_EXPORTER=true \
@@ -96,7 +101,7 @@ RUN install_packages ca-certificates curl gpg default-libmysqlclient-dev tzdata 
 
 # Add app user
 RUN groupadd -g 1001 app && \
-	useradd -u 1001 -g app app --home /app
+	useradd -u 1001 -g app app --home $APP_HOME
 
 # Make irb log history to a file
 RUN echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > irb.rc

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -89,7 +89,7 @@ ENV GEM_HOME=/usr/local/bundle \
 	TZ=Europe/London
 
 # Install node.js, yarn and other runtime dependencies
-RUN install_packages ca-certificates curl gpg build-essential default-libmysqlclient-dev tzdata libpq5 && \
+RUN install_packages ca-certificates curl gpg default-libmysqlclient-dev tzdata libpq5 && \
 	curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "/usr/share/keyrings/nodesource.gpg" >/dev/null && \
 	echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x jammy main" | tee /etc/apt/sources.list.d/nodesource.list && \
 	install_packages nodejs && npm i -g yarn

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -13,7 +13,8 @@ RUN : "${RUBY_MAJOR?}" "${RUBY_VERSION?}" "${RUBY_DOWNLOAD_SHA256?}"
 ENV LANG=C.UTF-8 \
   RUBY_MAJOR=${RUBY_MAJOR} \
   RUBY_VERSION=${RUBY_VERSION} \
-  RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+  RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256} \
+  MAKEFLAGS=-j"$(nproc)"
 
 # Install build dependencies
 RUN install_packages build-essential bison dpkg-dev libgdbm-dev ruby wget autoconf zlib1g-dev libreadline-dev checkinstall
@@ -27,7 +28,7 @@ RUN set -eux; \
 	cd /usr/src/openssl; \
 	./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib; \
 	make; \
-	make install;
+	make install_sw;  # Avoid building manpages and such.
 
 # Build Ruby
 RUN set -eux; \

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -82,6 +82,7 @@ ENV APP_HOME=/app \
 	BUNDLE_PATH=/usr/local/bundle \
 	BUNDLE_BIN=/usr/local/bundle/bin \
 	PATH=/usr/local/bundle/bin:$PATH \
+	IRBRC=/etc/irb.rc \
 	RAILS_LOG_TO_STDOUT=1 \
 	RAILS_ENV=production \
 	NODE_ENV=production \
@@ -104,6 +105,6 @@ RUN groupadd -g 1001 app && \
 	useradd -u 1001 -g app app --home $APP_HOME
 
 # Make irb log history to a file
-RUN echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > irb.rc
+RUN echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > "$IRBRC"
 
 LABEL org.opencontainers.image.source=https://github.com/alphagov/govuk-ruby-images

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -104,6 +104,10 @@ RUN install_packages ca-certificates curl gpg default-libmysqlclient-dev tzdata 
 RUN groupadd -g 1001 app && \
 	useradd -u 1001 -g app app --home $APP_HOME
 
+# Some Rubygems (libraries) assume that they can write to tmp/ within the Rails
+# app's base directory.
+RUN mkdir -p $APP_HOME && ln -fs /tmp $APP_HOME
+
 # Make irb log history to a file
 RUN echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > "$IRBRC"
 

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -4,8 +4,9 @@ FROM public.ecr.aws/lts/ubuntu:22.04_stable AS builder
 COPY install_packages.sh /usr/sbin/install_packages
 RUN chmod 755 /usr/sbin/install_packages
 
-# Build args to specify which Ruby version to build
+# Fail fast if mandatory build args are missing.
 ARG RUBY_MAJOR RUBY_VERSION RUBY_DOWNLOAD_SHA256
+RUN : "${RUBY_MAJOR?}" "${RUBY_VERSION?}" "${RUBY_DOWNLOAD_SHA256?}"
 
 # Set environment variables required for build
 ENV LANG=C.UTF-8 \

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -61,11 +61,11 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install;
 
+
 FROM public.ecr.aws/lts/ubuntu:22.04_stable
 
 # Copy helper script for package installation
-COPY install_packages.sh /usr/sbin/install_packages
-RUN chmod 755 /usr/sbin/install_packages
+COPY --from=builder /usr/sbin/install_packages /usr/sbin/install_packages
 
 # Copy Ruby binaries from builder image
 COPY --from=builder /build /

--- a/build.sh
+++ b/build.sh
@@ -1,28 +1,37 @@
 #!/bin/bash
+#
+# To run without pushing to DockerHub, set DRY_RUN to anything other than the
+# empty string. For example:
+#
+#     DRY_RUN=1 ./build.sh
+#
+
+set -eu
 
 for VERSION in versions/*; do
   RUBY_IS_PATCH=false
-  source $VERSION
-  echo "Building image for Ruby ${RUBY_MAJOR} (${RUBY_VERSION})"
-  # Build & push base image
-  docker build . -t "ghcr.io/alphagov/govuk-ruby-base:${RUBY_MAJOR}" \
-    -f base.Dockerfile \
-    --build-arg "RUBY_MAJOR=${RUBY_MAJOR}" \
-    --build-arg "RUBY_VERSION=${RUBY_VERSION}" \
-    --build-arg "RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}"
-  docker tag "ghcr.io/alphagov/govuk-ruby-base:${RUBY_MAJOR}" "ghcr.io/alphagov/govuk-ruby-base:${RUBY_VERSION}"
-  if [ "${RUBY_IS_PATCH}" != "true" ]; then
-    docker push "ghcr.io/alphagov/govuk-ruby-base:${RUBY_MAJOR}"
-  fi
-  docker push "ghcr.io/alphagov/govuk-ruby-base:${RUBY_VERSION}"
+  source "${VERSION}"
 
-  # Build & push builder image
-  docker build . -t "ghcr.io/alphagov/govuk-ruby-builder:${RUBY_MAJOR}" \
-    -f builder.Dockerfile \
-    --build-arg "RUBY_MAJOR=${RUBY_MAJOR}"
-  docker tag "ghcr.io/alphagov/govuk-ruby-builder:${RUBY_MAJOR}" "ghcr.io/alphagov/govuk-ruby-builder:${RUBY_VERSION}"
-  if [ "${RUBY_IS_PATCH}" != "true" ]; then
-    docker push "ghcr.io/alphagov/govuk-ruby-builder:${RUBY_MAJOR}"
-  fi
-  docker push "ghcr.io/alphagov/govuk-ruby-builder:${RUBY_VERSION}"
+  for IMAGE_TYPE in base builder; do
+    echo "Building ${IMAGE_TYPE} image for Ruby ${RUBY_MAJOR} (${RUBY_VERSION})"
+    IMAGE_NAME="govuk-ruby-${IMAGE_TYPE}"
+    docker build . \
+      -t "ghcr.io/alphagov/${IMAGE_NAME}:${RUBY_MAJOR}" \
+      -f "${IMAGE_TYPE}.Dockerfile" \
+      --build-arg "RUBY_MAJOR=${RUBY_MAJOR}" \
+      --build-arg "RUBY_VERSION=${RUBY_VERSION}" \
+      --build-arg "RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}"
+    docker tag \
+      "ghcr.io/alphagov/${IMAGE_NAME}:${RUBY_MAJOR}" \
+      "ghcr.io/alphagov/${IMAGE_NAME}:${RUBY_VERSION}"
+
+    if [[ -n ${DRY_RUN} ]]; then
+      echo "DRY_RUN is set so not pushing to DockerHub"
+    else
+      if [[ "${RUBY_IS_PATCH}" != "true" ]]; then
+        docker push "ghcr.io/alphagov/${IMAGE_NAME}:${RUBY_MAJOR}"
+      fi
+      docker push "ghcr.io/alphagov/${IMAGE_NAME}:${RUBY_VERSION}"
+    fi
+  done
 done

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,7 +1,7 @@
 ARG RUBY_MAJOR
 FROM ghcr.io/alphagov/govuk-ruby-base:${RUBY_MAJOR}
 
-RUN install_packages git libpq-dev
+RUN install_packages build-essential git libpq-dev
 
 # Environment variables to make build cleaner and faster
 ENV BUNDLE_IGNORE_MESSAGES=1 \


### PR DESCRIPTION
Apply the `ln -s /tmp /app/tmp` workaround to the base image so we don't have to deal with it multiple times as we add the rest of the publisher apps. Several apps need it because some rubygems assume that `$APP_HOME/tmp` is writeable (and I'm pretty sure it's unsound to just set `$APP_HOME` somewhere other than the root of the app's install path).

See commit messages for other details.

- Dev/test cycle time improvements
    - Fail fast when required build args are missing.
    - Add a dry-run mode to the build script and make it executable.
    - `set -o pipefail` in shell options in the Dockerfile.
    - Speed up the OpenSSL build.
    - Move build-essential packages to the builder image (also saves ~200 MB from the app image footprint).
 
- Other minor improvements
    - Factor out some env vars from the per-app Dockerfiles
    - Fix IRB history config to avoid errors on irb shutdown.
    - Copy `install_packages` script from the builder image.
    - Fix the mixture of hard and soft tabs in base.Dockerfile.

Tested: `DRY_RUN=1 ./build.sh` works and I was able to build a selection of different app images based on the base/builder images produced.