### PR TITLE
Stop building Ruby 2.7.5 images.

### DIFF
--- a/versions/2_7_5
+++ b/versions/2_7_5
@@ -1,5 +1,0 @@
-# TODO: Stop explicitly using patch versions
-RUBY_MAJOR="2.7"
-RUBY_VERSION="2.7.5"
-RUBY_DOWNLOAD_SHA256="d216d95190eaacf3bf165303747b02ff13f10b6cfab67a9031b502a49512b516"
-RUBY_IS_PATCH=true


### PR DESCRIPTION
Nothing seems to be using them any more:
https://sourcegraph.com/search?q=govuk-ruby-base:2.7.5
https://sourcegraph.com/search?q=repo:alphagov+file:dockerfile+2.7.5