### PR TITLE
Fix the with_tmpdir_for_ruby wrappers (again).

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -108,6 +108,11 @@ RUN for wrapped_cmd in bundle puma pumactl rails rake "${ruby_bin}"/*; do \
 # `with_tmpdir_for_ruby`.
 ENV TMPDIR_FOR_RUBY_ORIGINAL_PATH=${PATH}
 ENV PATH=${TMPDIR_FOR_RUBY_WRAPPERS_DIR}:${PATH}
+# Crude smoke test. Assert that Ruby Dir.tmpdir returns a subdirectory of /tmp.
+RUN set -x; \
+    expected=/tmp; \
+    actual=$(ruby -e 'require "tmpdir"; puts(File.dirname(Dir.tmpdir))'); \
+    [ "${expected}" = "${actual}" ]
 
 # Install node.js, yarn and other runtime dependencies.
 RUN install_packages ca-certificates curl gpg default-libmysqlclient-dev tzdata libpq5 && \

--- a/with_tmpdir_for_ruby.sh
+++ b/with_tmpdir_for_ruby.sh
@@ -38,18 +38,23 @@ usage() {
 }
 
 if [ -n "${TMPDIR_FOR_RUBY:-}" ]; then
-  echo "TMPDIR_FOR_RUBY already set; aborting to avoid infinite loop (PATH=${PATH})" >&2
+  echo "ERROR: with_tmpdir_for_ruby: TMPDIR_FOR_RUBY already set; aborting to avoid infinite loop (PATH=${PATH})" >&2
   exit 1
 fi
 
 invoked_as="$(basename "${0%.sh}")"
 if [ "${invoked_as}" = "with_tmpdir_for_ruby" ]; then
   [ $# -eq 0 ] && usage
+  cmd=$1
   shift
+else
+  cmd=$0
 fi
+cmd=$(basename "${cmd}")
 
 PATH=$TMPDIR_FOR_RUBY_ORIGINAL_PATH
 TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/ruby-app-XXXXXXXX")"
 TMPDIR_FOR_RUBY=$TMPDIR
 export PATH TMPDIR TMPDIR_FOR_RUBY
-"$0" "$@"
+echo "INFO: with_tmpdir_for_ruby: execing ${cmd} with TMPDIR=${TMPDIR}" >&2
+exec "${cmd}" "$@"


### PR DESCRIPTION
- Copy the wrapper script into place after the env var that specifies its destination has been set.
- Abort on undefined shell variables (`set -u`), which would have caught the above.
- Fix a bug where the script would re-exec itself instead of the wrapped command.
- Instead of forking, just `exec` the wrapped command. This makes the script fail more predictably if you pass a shell builtin (like `set` or `echo`) as the command, and saves having a useless shell process hanging around for the lifetime of the server process.
- `BUNDLE_BIN` isn't populated at base image build time (d'oh).
- Add a smoke test for the wrapper script. This would have caught the above bug in the wrapper script.

#### Testing

* Did a bunch of manual testing with `DRY_RUN=1 ./build.sh 2_7 && docker run -it --rm -u1000 ghcr.io/alphagov/govuk-ruby-builder:2.7 bash` including
    * `with_tmpdir_for_ruby sh -c 'echo $TMPDIR $PATH'`
    * `irb`, checked that `Dir.tmpdir`, `mktmpdir` etc. work as expected.
    * `with_tmpdir_for_ruby sh` and checked that nesting the wrapper script fails with the expected error message.
* Checked that all the builds succeed on GitHub Actions (with the new smoke test).