### PR TITLE
Add gpg package to the builder image.

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,7 +1,7 @@
 ARG RUBY_MAJOR
 FROM ghcr.io/alphagov/govuk-ruby-base:${RUBY_MAJOR}
 
-RUN install_packages g++ libc-dev make git libmariadb-dev-compat libpq-dev xz-utils
+RUN install_packages g++ libc-dev make git gpg libmariadb-dev-compat libpq-dev xz-utils
 
 # Environment variables to make build cleaner and faster
 ENV BUNDLE_IGNORE_MESSAGES=1 \


### PR DESCRIPTION
This makes it easier to install apt packages from third-party repos when building downstream images.