### PR TITLE
Fix pushing to registry on scheduled builds.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,11 +8,11 @@ on:
         required: true
         type: string
         default: main
-      pushToRegistry:
-        description: Push images to registry
+      noPushToRegistry:
+        description: Build only, skip pushing to registry
         required: true
         type: boolean
-        default: true
+        default: false
   push:
     branches:
       - main
@@ -38,11 +38,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.gitRef }}
-      - name: Build and push images
-        if: ${{ inputs.pushToRegistry }}
-        run: ./build.sh ${{ matrix.version }}
       - name: Build images (without pushing to registry)
-        if: ${{ !inputs.pushToRegistry }}
+        if: ${{ inputs.noPushToRegistry }}
         env:
           DRY_RUN: "1"
+        run: ./build.sh ${{ matrix.version }}
+      - name: Build and push images
+        if: ${{ !inputs.noPushToRegistry }}
         run: ./build.sh ${{ matrix.version }}


### PR DESCRIPTION
Fixes a bug that I introduced in 7e874e7 (oops 🤦) where we'd default to `DRY_RUN=1` when the build is triggered by anything other than `workflow_dispatch` (i.e. on-demand builds).