### PR TITLE
[do not merge] Don't set `RAILS_LOG_TO_STDOUT` by default.

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -91,7 +91,6 @@ ENV APP_HOME=/app \
     PATH=/usr/local/bundle/bin:$PATH \
     IRBRC=/etc/irb.rc \
     XDG_DATA_HOME=/tmp \
-    RAILS_LOG_TO_STDOUT=1 \
     RAILS_ENV=production \
     NODE_ENV=production \
     BUNDLE_WITHOUT="development test cucumber" \


### PR DESCRIPTION
TODO: get to the bottom of why this doesn't work, i.e. where the default Rails logger comes from and why govuk_app_config doesn't seem to override it (at least in some cases) 🧐 

Turns out all GOV.UK apps that use the [govuk_app_config rubygem](https://github.com/alphagov/govuk_app_config/) already log to stdout/stderr, but by setting this env var we were enabling some [Rails boilerplate code] that overrides [govuk_app_config's logger] with one that doesn't have the configuration that we want.

This was causing all logs to be output as unstructured text rather than JSON, and possibly also causing log writes not to be flushed promptly (but see also https://github.com/alphagov/govuk_app_config/pull/277).

This didn't use to be a problem in some cases, because some apps didn't have the boilerplate `if ENV["RAILS_LOG_TO_STDOUT"].present?` condition in their `config/production.rb`. It seems some apps had this [added back] during the recent(ish) upgrades to Rails 7 because `rails app:update` prompts about it.

[govuk_app_config's logger]: https://github.com/alphagov/govuk_app_config/blob/main/lib/govuk_app_config/govuk_logging.rb
[Rails boilerplate code]: https://github.com/alphagov/publisher/blob/825f87c/config/environments/production.rb#L98
[added back]: https://github.com/alphagov/publisher/commit/825f87c?diff=unified#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eR98