### PR TITLE
Fix build on GitHub and revert to OpenSSL 1.1.1.

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -18,7 +18,7 @@ ENV LANG=C.UTF-8 \
 # Build-time dependencies for Ruby.
 # TODO: remove perl once we no longer need to build OpenSSL.
 # TODO: remove curl and gpg once downloads are done in the build script.
-RUN install_packages curl ca-certificates pkg-config g++ gpg libc-dev make bison patch libdb-dev libffi-dev libgdbm-dev libgmp-dev libreadline-dev libssl-dev libyaml-dev zlib1g-dev uuid-dev libjemalloc-dev perl
+RUN install_packages curl ca-certificates g++ gpg libc-dev make bison patch libdb-dev libffi-dev libgdbm-dev libgmp-dev libreadline-dev libssl-dev libyaml-dev zlib1g-dev uuid-dev libjemalloc-dev perl
 
 # Process the repo signing key for nodesource so we don't have to include gpg
 # in the final image.

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -28,10 +28,9 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dear
 # TODO: do the download and verification externally, in the build script.
 COPY SHA256SUMS /
 
-# TODO: remove the OpenSSL build once we're rid of Ruby 2.7.
+# TODO: remove OpenSSL build once https://www.github.com/ruby/openssl/issues/369 is fixed.
 WORKDIR /usr/src/openssl
 RUN set -x; \
-    [[ "$RUBY_MAJOR" != '2.7' ]] && exit 0; \
     MAKEFLAGS=-j"$(nproc)"; export MAKEFLAGS; \
     openssl_tarball="openssl-${OPENSSL_VERSION}.tar.gz"; \
     curl -fsSLO "https://www.openssl.org/source/${openssl_tarball}"; \
@@ -63,15 +62,13 @@ RUN set -x; \
       --disable-install-doc \
       --enable-shared \
       --with-jemalloc \
-      "$([[ -d /opt/openssl ]] && echo --with-openssl-dir=/opt/openssl)" \
+      --with-openssl-dir=/opt/openssl \
     ; \
     make; \
     make install; \
     gem update --system --silent --no-document; \
     gem pristine --extensions; \
     gem cleanup;
-# Ensure that /opt/openssl exists so that the COPY below doesn't fail.
-WORKDIR /opt/openssl
 
 
 FROM public.ecr.aws/lts/ubuntu:22.04_stable


### PR DESCRIPTION
Back out the `pkg-config` package, since this breaks cross-compilation and this was causing builds to fail on GitHub Actions (but not local `docker build`).

Also revert to OpenSSL 1.1.1 for all Ruby versions, as it turns out the `openssl` rubygem [doesn't fully support OpenSSL 3 yet](https://www.github.com/ruby/openssl/issues/369). It works, but not all of its tests are passing and the compiler emits a ton of warnings about deprecated APIs and discarded `const`ness.

Partially reverts #36.

Tested: builds succeed [on GitHub Actions](https://github.com/alphagov/govuk-ruby-images/actions/runs/3941536687) as well as Docker Desktop. [Whitehall builds successfully on the new image](https://github.com/alphagov/whitehall/actions/runs/3941789850) and works on the integration cluster.