### PR TITLE
Enable jemalloc via `LD_PRELOAD` instead of `--with-jemalloc`.

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -61,7 +61,6 @@ RUN set -x; \
       --mandir=/tmp/throwaway \
       --disable-install-doc \
       --enable-shared \
-      --with-jemalloc \
       --with-openssl-dir=/opt/openssl \
     ; \
     make; \
@@ -106,6 +105,8 @@ ENV APP_HOME=/app \
     GOVUK_PROMETHEUS_EXPORTER=true \
     DEBIAN_FRONTEND=noninteractive \
     TZ=Europe/London
+# Use jemalloc by default.
+ENV LD_PRELOAD=libjemalloc.so
 
 # Amazon RDS cert bundle for connecting to managed databases over TLS.
 ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -18,7 +18,7 @@ ENV LANG=C.UTF-8 \
 # Build-time dependencies for Ruby.
 # TODO: remove perl once we no longer need to build OpenSSL.
 # TODO: remove curl and gpg once downloads are done in the build script.
-RUN install_packages curl ca-certificates g++ gpg libc-dev make bison patch libdb-dev libffi-dev libgdbm-dev libgmp-dev libreadline-dev libssl-dev libyaml-dev zlib1g-dev uuid-dev libjemalloc-dev perl
+RUN install_packages curl ca-certificates g++ gpg libc-dev make bison patch libdb-dev libffi-dev libgdbm-dev libgmp-dev libreadline-dev libyaml-dev zlib1g-dev uuid-dev libjemalloc-dev perl
 
 # Process the repo signing key for nodesource so we don't have to include gpg
 # in the final image.


### PR DESCRIPTION
This makes it easy to switch back to glibc malloc without rebuilding, e.g. for future benchmarking or comparison if there's any suspicion of a problem. As a bonus, we also cover other processes `exec`ed by Ruby, rather than just Ruby itself.

While we're there, avoid unnecessarily installing the `libssl-dev` package, which we weren't using.