### PR TITLE
Update action-shellcheck from 1.1.0 to 2.0.0.

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9  # 1.1.0
+      uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
   hadolint:
     name: Hadolint
     runs-on: ubuntu-latest


### PR DESCRIPTION
[Release notes](https://www.github.com/ludeeus/action-shellcheck/releases/tag/2.0.0)