### PR TITLE
Fix missing `set -e` and a broken test.

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -157,7 +157,7 @@ RUN echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > "$IRBRC"
 RUN set -x; \
     ruby --version; \
     echo RUBY_DESCRIPTION | irb; \
-    echo 'puts OpenSSL::OPENSSL_VERSION' | ruby -r openssl \
+    echo 'puts OpenSSL::OPENSSL_VERSION' | ruby -r openssl; \
     gem env; \
     bundle version; \
     rm -r /tmp/*;


### PR DESCRIPTION
Hadolint doesn't catch the missing `set -e` for some reason :(

This was masking a test failure, caused by a missing semicolon in #36 😅