### PR TITLE
Add libyaml headers to builder image.

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,7 +1,9 @@
 ARG RUBY_MAJOR
 FROM ghcr.io/alphagov/govuk-ruby-base:${RUBY_MAJOR}
 
-RUN install_packages g++ libc-dev libssl-dev make git gpg libmariadb-dev-compat libpq-dev xz-utils
+RUN install_packages \
+    g++ libc-dev libssl-dev make git gpg libmariadb-dev-compat libpq-dev \
+    libyaml-dev xz-utils
 
 # Environment variables to make build cleaner and faster
 ENV BUNDLE_IGNORE_MESSAGES=1 \


### PR DESCRIPTION
The `psych` gem needs to compile against libyaml.

Not sure why we're only running into this now — maybe Rails was happy with our stock version of `psych` until recently? — but in any case it seems sensible to include headers in the builder image for libraries that we ship in our base image.