### PR TITLE
Add remaining missing headers to builder image.

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -2,8 +2,8 @@ ARG RUBY_MAJOR
 FROM ghcr.io/alphagov/govuk-ruby-base:${RUBY_MAJOR}
 
 RUN install_packages \
-    g++ libc-dev libssl-dev make git gpg libmariadb-dev-compat libpq-dev \
-    libyaml-dev xz-utils
+    g++ git gpg libc-dev libcurl4-openssl-dev libgdbm-dev libssl-dev \
+    libmariadb-dev-compat libpq-dev libyaml-dev make xz-utils
 
 # Environment variables to make build cleaner and faster
 ENV BUNDLE_IGNORE_MESSAGES=1 \


### PR DESCRIPTION
We're not using any of these yet, but it makes sense to ship headers in the builder image for all the libraries that we include in the base image. Should reduce the chance of being caught out next time some dependency starts requiring a native rubygem that depends on any of those libs.