### PR TITLE
Add new RDS CA root/intermediate certs.

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -88,7 +88,9 @@ ENV APP_HOME=/app \
     TZ=Europe/London
 
 # Amazon RDS cert bundle for connecting to managed databases over TLS.
+# TODO: remove rds-combined-ca-bundle.pem once Router API is using global-bundle.pem.
 ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/rds-global-bundle.pem
 
 # Wrap Ruby binaries in a script that sets up a TMPDIR that Ruby will accept.
 # TODO: remove this when Ruby allows disabling its permissions checks on /tmp.


### PR DESCRIPTION
Only Router API uses this AFAICT. At some point we'll have to switch its RDS instance to use the new CA and then it'll need the new roots.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL