### PR TITLE
Pin Yarn to 1.22.19.

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -115,7 +115,7 @@ RUN install_packages ca-certificates curl libjemalloc-dev libgdbm6 libyaml-0-2 \
     install_packages nodejs; \
     echo -n node version:\ ; node -v; \
     echo -n npm version:\ ; npm -v; \
-    npm install -g yarn@1
+    npm install -g yarn@1.22.19
 
 # Use jemalloc by default.
 ENV LD_PRELOAD=libjemalloc.so


### PR DESCRIPTION
Yarn 1.22.20 and 1.22.21 (current) have a nasty regression which breaks `yarn install --immutable` for at least [alphagov/frontend](https://github.com/alphagov/frontend/pull/3859).