### PR TITLE
Make multi-arch builds the default now.

### DIFF
--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -15,7 +15,9 @@ on:
         default: true
   push:
     branches:
-      - GIFT-multiarch
+      - main
+  schedule:
+    - cron: '0 3 * * *'
 
 jobs:
   build_and_push_amd64:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,11 +13,6 @@ on:
         required: true
         type: boolean
         default: false
-  push:
-    branches:
-      - main
-  schedule:
-    - cron: '0 3 * * *'
 
 jobs:
   build_and_push:

--- a/.github/workflows/sign.yaml
+++ b/.github/workflows/sign.yaml
@@ -2,7 +2,7 @@ name: Sign container images
 
 on:
   workflow_run:
-    workflows: ["Build and push images"]
+    workflows: ["Build and push multi-arch images"]
     types:
       - completed
   workflow_dispatch:


### PR DESCRIPTION
## What?
So we previously merged-in the new multi-architecture build job, but it is currently does not trigger on main. This should switch things around so that we are now using the multi-arch builds job by default.

I'm hoping the image signing job will continue to work as-is.

## Related PRs
* https://github.com/alphagov/govuk-ruby-images/pull/68