### PR TITLE
This matrix was missed when bumping Ruby 3.2

### DIFF
--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -256,7 +256,7 @@ jobs:
       matrix:
         version: [
           {rubyver: ['3', '1', '4'], extra: ''},
-          {rubyver: ['3', '2', '2'], extra: ''},
+          {rubyver: ['3', '2', '3'], extra: ''},
           {rubyver: ['3', '3', '0'], extra: 'latest'},
         ]
     permissions:


### PR DESCRIPTION
## What?
As we do a checksum.... check when pulling Ruby, the build failed because The ARM build matrix still contains 3.2.2 rather than 3.2.3.