### PR TITLE
Correct another matrix - we missed another one!

### DIFF
--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -137,7 +137,7 @@ jobs:
       matrix:
         version: [
           {rubyver: ['3', '1', '4'], extra: ''},
-          {rubyver: ['3', '2', '2'], extra: ''},
+          {rubyver: ['3', '2', '3'], extra: ''},
           {rubyver: ['3', '3', '0'], extra: 'latest'},
         ]
     permissions:


### PR DESCRIPTION
## What?
Turns out there's _three_ matrixes with the same information.

It's a shame that Github doesn't give us an easy way to address this by reusing a single matrix across multiple jobs, huh?

...or maybe there is?