### PR TITLE
Stop Manifest Job running more times than needed

### DIFF
--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -149,7 +149,8 @@ jobs:
       - build_and_push_image
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJson(needs.configure_builds.outputs.matrix) }}
+      matrix: 
+        version: ${{ fromJson(needs.configure_builds.outputs.matrix.version) }}
     permissions:
       packages: write
     steps:


### PR DESCRIPTION
## What?
With the "improvements" to the main job matrix, we are now running the Manifest job more times than necessary.

This change should adjust the Manifest matrix so it only runs once per version, rather than twice.