### PR TITLE
Try to fix the digest error.

### DIFF
--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -130,7 +130,7 @@ jobs:
             RUBY_CHECKSUM=${{ matrix.version.checksum }}
           tags: ${{ steps.base-image-metadata.outputs.tags }}
           labels: ${{ steps.base-image-metadata.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_BASE }}/govuk-ruby-base,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY_BASE }}/govuk-ruby-base,push-by-digest=true,name-canonical=true
           cache-from: type=gha,scope=build-base-${{ matrix.arch }}
           cache-to: type=gha,scope=build-base-${{ matrix.arch }},mode=max
 
@@ -149,7 +149,7 @@ jobs:
             OWNER=${{ github.repository_owner }}
           tags: ${{ steps.builder-image-metadata.outputs.tags }}
           labels: ${{ steps.builder-image-metadata.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_BASE }}/govuk-ruby-builder,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY_BASE }}/govuk-ruby-builder,push-by-digest=true,name-canonical=true
           cache-from: type=gha,scope=build-builder-${{ matrix.arch }}
           cache-to: type=gha,scope=build-builder-${{ matrix.arch }},mode=max
 


### PR DESCRIPTION
## What?
We're getting a somewhat cryptic error message:

```
buildx failed with: ERROR: failed to solve: failed to push ghcr.io/alphagov/govuk-ruby-base:3.3.0: can't push tagged ref ghcr.io/alphagov/govuk-ruby-base:3.3.0 by digest
```

I'm not sure if this is because it is already trying to push the image with a tag before it has consolidated the different architecture images from across the different builds. But let's see if it's because `push-by-digest` doesn't replace/override the `push` option (these options appear to be poorly documented)