### PR TITLE
Update README to reflect the new build config.

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2022 Crown Copyright (Government Digital Service)
+Copyright © 2022-2024 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The README had gotten pretty out of date with recent improvements to the way we're configuring the builds.

Fix the instructions and give the rest of the doc an editorial sprucing up.

[Preview](https://github.com/alphagov/govuk-ruby-images/blob/sengi/readme/README.md)