### PR TITLE
Ruby 3.3.3 and Ubuntu 24.04 LTS

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM public.ecr.aws/lts/ubuntu:22.04_stable AS builder
+FROM --platform=$TARGETPLATFORM public.ecr.aws/lts/ubuntu:24.04_stable AS builder
 ARG TARGETARCH
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
@@ -60,7 +60,7 @@ RUN set -x; \
     gem cleanup;
 
 
-FROM --platform=$TARGETPLATFORM public.ecr.aws/lts/ubuntu:22.04_stable
+FROM --platform=$TARGETPLATFORM public.ecr.aws/lts/ubuntu:24.04_stable
 
 LABEL org.opencontainers.image.title="govuk-ruby-base"
 LABEL org.opencontainers.image.authors="GOV.UK Platform Engineering"

--- a/build-matrix.json
+++ b/build-matrix.json
@@ -9,9 +9,9 @@
         },
         {
             "rubyver": [
-                "3", "3", "1"
+                "3", "3", "3"
             ],
-            "checksum": "8dc2af2802cc700cd182d5430726388ccf885b3f0a14fcd6a0f21ff249c9aa99",
+            "checksum": "83c05b2177ee9c335b631b29b8c077b4770166d02fa527f3a9f6a40d13f3cce2",
             "extra": "latest"
         }
     ],


### PR DESCRIPTION
## What?
This bumps two different things:

- Ruby 3.3.3 (up from Ruby 3.3.1)
- Ubuntu 24.04 LTS (up from Ubuntu 22.04 LTS)

As far as I can tell, there isn't a reason why we are stuck on Ubuntu 22.04 - this just keeps us on the latest LTS version of the OS.