### PR TITLE
Use the Nodesource Setup script for Node/NPM

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -37,10 +37,6 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dear
 WORKDIR /usr/src/ruby
 RUN set -x; \
     MAKEFLAGS=-j"$(nproc)"; export MAKEFLAGS; \
-    if [[ "$RUBY_VERSION" = "3.3.0" && "$TARGETARCH" = "arm64" ]]; then \
-      : "workaround for https://bugs.ruby-lang.org/issues/20085"; \
-      ASFLAGS="-mbranch-protection=pac-ret"; export ASFLAGS; \
-    fi; \
     ruby_tarball="ruby-${RUBY_VERSION}.tar.gz"; \
     curl -fsSLO "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR}/${ruby_tarball}"; \
     echo "${RUBY_CHECKSUM} ${ruby_tarball}" | sha256sum --check --strict --status; \
@@ -123,8 +119,8 @@ ENV PATH=${TMPDIR_FOR_RUBY_WRAPPERS_DIR}:${PATH}
 COPY --from=builder /usr/share/keyrings/nodesource.gpg /usr/share/keyrings/
 RUN install_packages ca-certificates curl libjemalloc-dev libgdbm6 libyaml-0-2 \
       libmariadb3 libpq5 mariadb-client postgresql-client tzdata; \
-    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x jammy main" | tee /etc/apt/sources.list.d/nodesource.list; \
-    install_packages nodejs; \
+      curl -fsSL https://deb.nodesource.com/setup_18.x | bash; \
+    apt-get install -y nodejs; \
     echo -n node version:\ ; node -v; \
     echo -n npm version:\ ; npm -v; \
     npm install -g yarn@1.22.19


### PR DESCRIPTION
## What?
It seems like Nodesource has changed the way you install Node via their Apt Source, as I couldn't simply get it working by just specifying "noble" as the Distro codename. The script they provide now just seems to work whatever Distro you're using.

Result: We end up with an image that comes with Node 18 and NPM 10, which is what we had before. If we want to upgrade to Node 20 or 22, that should be easy.