### PR TITLE
Add libjsonnet++ for publishing-api Content Schemas.

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -118,7 +118,8 @@ ENV PATH=${TMPDIR_FOR_RUBY_WRAPPERS_DIR}:${PATH}
 # Install node.js, yarn and other runtime dependencies.
 COPY --from=builder /usr/share/keyrings/nodesource.gpg /usr/share/keyrings/
 
-RUN install_packages ca-certificates curl libjemalloc-dev libgdbm6 libyaml-0-2 \
+RUN install_packages ca-certificates curl libjemalloc-dev libgdbm6 \
+      libjsonnet0 libyaml-0-2 \
       libmariadb3 libpq5 mariadb-client postgresql-client tzdata; \
       curl -fsSL https://deb.nodesource.com/setup_18.x | bash; \
     install_packages nodejs; \

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=$TARGETPLATFORM ghcr.io/${OWNER}/govuk-ruby-base@${BASE_IMAGE_DI
 
 RUN install_packages \
     g++ git gpg libc-dev libcurl4-openssl-dev libgdbm-dev libssl-dev \
-    libmariadb-dev-compat libpq-dev libyaml-dev make xz-utils
+    libmariadb-dev-compat libpq-dev libjsonnet-dev libyaml-dev make xz-utils
 
 # Environment variables to make build cleaner and faster
 ENV BUNDLE_IGNORE_MESSAGES=1 \


### PR DESCRIPTION
Only publishing-api strictly needs this right now, but it's a small library so adding it here is reasonable. Saves having to pull down the Apt catalog in the pubapi build, and reduces the chance of copypasta/cargo-culting extra steps from the pubapi Dockerfile.

See https://github.com/alphagov/publishing-api/pull/2788.