### PR TITLE
Remove support for pinning obsolete Ruby versions.

### DIFF
--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -9,7 +9,7 @@ on:
         type: string
         default: main
       pushToRegistry:
-        description: Push to Registry. Set to false to test the build without pushing.
+        description: Push to image registry. Set to false to build without pushing.
         required: true
         type: boolean
         default: true
@@ -96,15 +96,14 @@ jobs:
           images: |
             ${{ env.REGISTRY_BASE }}/govuk-ruby-base
           tags: |
-            type=semver,pattern={{raw}},value=${{ join(matrix.version.rubyver, '.') }}
             type=raw,value=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}
             type=raw,value=latest,enable=${{ matrix.version.extra == 'latest' }}
-            type=sha,enable=true,prefix=${{ join(matrix.version.rubyver, '.') }}-,format=short
-            type=sha,enable=true,priority=100,format=long,prefix=${{ join(matrix.version.rubyver, '.') }}-
+            type=sha,enable=true,prefix=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}-,format=short
+            type=sha,enable=true,priority=100,format=long,prefix=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}-
           labels: |
             org.opencontainers.image.title=govuk-ruby-base
             org.opencontainers.image.authors="GOV.UK Platform Engineering"
-            org.opencontainers.image.description="Base Image for GOV.UK Ruby-based Apps"
+            org.opencontainers.image.description="Base image for GOV.UK Ruby apps"
             org.opencontainers.image.source="https://github.com/alphagov/govuk-ruby-images"
             org.opencontainers.image.version=${{ join(matrix.version.rubyver, '.') }}
             org.opencontainers.image.created=${{ steps.calculate-image-tags.outputs.createdDate }}
@@ -119,11 +118,10 @@ jobs:
           images: |
             ${{ env.REGISTRY_BASE }}/govuk-ruby-builder
           tags: |
-            type=semver,pattern={{raw}},value=${{ join(matrix.version.rubyver, '.') }}
             type=raw,value=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}
             type=raw,value=latest,enable=${{ matrix.version.extra == 'latest' }}
-            type=sha,enable=true,prefix=${{ join(matrix.version.rubyver, '.') }}-,format=short
-            type=sha,enable=true,priority=100,format=long,prefix=${{ join(matrix.version.rubyver, '.') }}-
+            type=sha,enable=true,prefix=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}-,format=short
+            type=sha,enable=true,priority=100,format=long,prefix=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}-
           labels: |
             org.opencontainers.image.title=govuk-ruby-builder
             org.opencontainers.image.authors="GOV.UK Platform Engineering"
@@ -230,17 +228,16 @@ jobs:
           labels: |
             org.opencontainers.image.title=govuk-ruby-base
             org.opencontainers.image.authors="GOV.UK Platform Engineering"
-            org.opencontainers.image.description="Base Image for GOV.UK Ruby-based Apps"
+            org.opencontainers.image.description="Base image for GOV.UK Ruby apps"
             org.opencontainers.image.source="https://github.com/alphagov/govuk-ruby-images"
             org.opencontainers.image.version=${{ join(matrix.version.rubyver, '.') }}
             org.opencontainers.image.created=${{ steps.calculate-image-tags.outputs.createdDate }}
             org.opencontainers.image.vendor=GDS
           tags: |
-            type=semver,pattern={{raw}},value=${{ join(matrix.version.rubyver, '.') }}
             type=raw,value=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}
             type=raw,value=latest,enable=${{ matrix.version.extra == 'latest' }}
-            type=sha,enable=true,prefix=${{ join(matrix.version.rubyver, '.') }}-,format=short
-            type=sha,enable=true,priority=100,format=long,prefix=${{ join(matrix.version.rubyver, '.') }}-
+            type=sha,enable=true,prefix=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}-,format=short
+            type=sha,enable=true,priority=100,format=long,prefix=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}-
 
       - name: Create Manifest Lists (for Base)
         working-directory: /tmp/digests/base
@@ -265,11 +262,10 @@ jobs:
             org.opencontainers.image.created=${{ steps.calculate-image-tags.outputs.createdDate }}
             org.opencontainers.image.vendor=GDS
           tags: |
-            type=semver,pattern={{raw}},value=${{ join(matrix.version.rubyver, '.') }}
             type=raw,value=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}
             type=raw,value=latest,enable=${{ matrix.version.extra == 'latest' }}
-            type=sha,enable=true,prefix=${{ join(matrix.version.rubyver, '.') }}-,format=short
-            type=sha,enable=true,priority=100,format=long,prefix=${{ join(matrix.version.rubyver, '.') }}-
+            type=sha,enable=true,prefix=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}-,format=short
+            type=sha,enable=true,priority=100,format=long,prefix=${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}-
 
       - name: Create Manifest Lists (for Builder)
         working-directory: /tmp/digests/builder

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ The govuk-ruby-images repository defines [OCI] container images for building and
 
 ## Usage
 
-Use the two images in your app's Dockerfile:
+Use the two images in your app's Dockerfile.
+
+Specify the image tag that corresponds to the `<major>.<minor>` Ruby version that your application needs.
+
 
 ```dockerfile
 ARG ruby_version=3.3
@@ -39,6 +42,35 @@ FROM $base_image
 See [alphagov/frontend/Dockerfile](https://github.com/alphagov/frontend/blob/-/Dockerfile) for a full, real-world example.
 
 
+## Supported tags
+
+Our version maintenance policy is similar to [upstream](https://www.ruby-lang.org/en/downloads/branches/) except that we drop support for a (major.minor) version series once it's no longer in use in GOV.UK.
+
+See [build-matrix.json](build-matrix.json#L2) for the list of Ruby versions we currently support.
+
+> [!IMPORTANT]
+> Please do not attempt to specify the Ruby patch version. See [below](#if-you-suspect-a-bug) for alternatives.
+
+
+### If you suspect a bug
+
+If you encounter a bug in govuk-ruby-images that breaks your application or your build:
+
+- if absolutely necessary, you **may** *temporarily* pin a known-good [base](https://github.com/alphagov/govuk-ruby-images/pkgs/container/govuk-ruby-base) and/or [builder](https://github.com/alphagov/govuk-ruby-images/pkgs/container/govuk-ruby-builder) image by SHA or SHA prefix, for example:
+
+    ```Dockerfile
+    # TODO(https://github.com/alphagov/govuk-ruby-images/issues/96): remove pinned image once bug is fixed.
+    ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.3-acecafe
+    ```
+
+- if you pin a base/builder image SHA, you **must**:
+
+  - [file an issue](https://github.com/alphagov/govuk-ruby-images/issues/new) so that the maintainers know there is a problem that needs to be addressed
+  - add a TODO containing a link to the issue, so that the workaround can be cleaned up once the issue is fixed
+
+If you are unsure, ask [Platform Engineering team](#team) for advice.
+
+
 ## Common problems and resolutions
 
 `ERROR: failed to solve: cannot copy to non-directory: /var/lib/docker/overlay2/.../merged/app/tmp`
@@ -49,7 +81,10 @@ assume they can write to `Path.join(Rails.root, 'tmp')` so that we can run with
 `readOnlyRootFilesystem`.
 
 
-## Add or update a Ruby version
+## Maintenance
+
+
+### Add or update a Ruby version
 
 The file [build-matrix.json](/build-matrix.json) defines the Ruby versions and image tags that we build.
 
@@ -58,6 +93,6 @@ The `checksum` field is currently the SHA-256 hash of the Ruby source tarball. W
 See [Ruby Releases](https://www.ruby-lang.org/en/downloads/releases/) for the list of available Ruby tarballs and their SHA digests.
 
 
-## Team
+### Team
 
-[GOV.UK Platform Engineering team](https://github.com/orgs/alphagov/teams/gov-uk-platform-engineering) looks after this repo. If you're inside GDS, you can find us in [#govuk-platform-engineering](https://gds.slack.com/channels/govuk-platform-engineering) or view our [kanban board](https://github.com/orgs/alphagov/projects/71).
+[GOV.UK Platform Engineering team](https://github.com/orgs/alphagov/teams/gov-uk-platform-engineering) looks after this repo. If you're inside GDS, you can find us in [#govuk-platform-engineering](https://gds.slack.com/channels/govuk-platform-engineering) or view our [project board](https://github.com/orgs/alphagov/projects/71).

--- a/build.sh
+++ b/build.sh
@@ -36,14 +36,11 @@ build_version() {
       --build-arg "RUBY_VERSION=${ruby_version}" \
       --build-arg "RUBY_CHECKSUM=$(sha_for_version "$ruby_version")" \
       -t "ghcr.io/alphagov/${image_name}:${ruby_major_minor}" \
-      -t "ghcr.io/alphagov/${image_name}:${ruby_major_minor}" \
-      -t "ghcr.io/alphagov/${image_name}:${ruby_version}" \
       -f "${img}.Dockerfile" .
 
     if [[ ${PUSH_TO_REGISTRY:-} = "1" ]]; then
       echo "pushing to registry"
       docker push "ghcr.io/alphagov/${image_name}:${ruby_major_minor}"
-      docker push "ghcr.io/alphagov/${image_name}:${ruby_version}"
     fi
   done
 }


### PR DESCRIPTION
We recently encountered a problem (#96) where a downstream repo was unwittingly pinning an image tag for an obsolete Ruby patch version (which we've never supported, but this wasn't very clear to app dev teams) and removing the unwanted pin uncovered other brokenness that was being masked by remaining on the obsolete builder image.

Explicitly remove support for obsolete Ruby patch versions so that other feature teams can't repeat the same mistake.

For security reasons we should never be running an old Ruby patch version; we'd always either fix forward (like we did with https://bugs.ruby-lang.org/issues/20085) or temporarily pin Ruby within govuk-ruby-images until upstream releases a fix. There's no valid reason for app teams to specify an old patch version.

There are currently no consumers specifying the Ruby patch version image tags.

Tested: https://github.com/alphagov/govuk-ruby-images/actions/runs/9697289736