### PR TITLE
Use preinstalled Docker from the runner image.

### DIFF
--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -49,24 +49,6 @@ jobs:
     permissions:
       packages: write
     steps:
-      - name: Install Docker (Github ARM Only)
-        if: ${{ matrix.runs_on.runner_type == 'arm64-runner' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-          sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-          sudo usermod -a -G docker $USER
-          sudo apt-get install acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:

--- a/build-matrix.json
+++ b/build-matrix.json
@@ -21,7 +21,7 @@
             "arch": "amd64"
         },
         {
-            "runner_type": "arm64-runner",
+            "runner_type": "ubuntu-24.04-arm",
             "arch": "arm64"
         }
     ]


### PR DESCRIPTION
We no longer need to install Docker ourselves now that https://github.com/actions/partner-runner-images/tree/main/images are available.

Should speed up builds somewhat.

Tested: https://github.com/alphagov/govuk-ruby-images/actions/runs/9697782700/job/26762749352