### PR TITLE
Grant packages.write to image GC job.

### DIFF
--- a/.github/workflows/gc.yaml
+++ b/.github/workflows/gc.yaml
@@ -9,6 +9,8 @@ jobs:
   gc_old_images:
     name: Delete untagged images except for the most recent 10
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     strategy:
       matrix:
         pkg:


### PR DESCRIPTION
The [delete-package-versions docs](https://github.com/actions/delete-package-versions/blob/-/README.md) don't mention it, but it fails without `packages: write`.

Indeed [their test](https://github.com/actions/delete-package-versions/blob/063586/.github/workflows/test.yml#L10) has it.