### PR TITLE
Garbage-collect old, tagged-but-unsupported images.

### DIFF
--- a/.github/workflows/gc.yaml
+++ b/.github/workflows/gc.yaml
@@ -1,4 +1,4 @@
-name: Garbage-collect untagged images
+name: Garbage-collect old images
 
 on:
   schedule:
@@ -6,9 +6,31 @@ on:
   workflow_dispatch:
 
 jobs:
-  gc_old_images:
-    name: Delete untagged images except for the most recent 10
+  read_tags:
+    name: Read tags from build-matrix.json
     runs-on: ubuntu-latest
+    outputs:
+      supported_tags_regex: ${{ steps.get_tags.outputs.supported_tags_regex }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - id: get_tags
+        run: |
+          # Construct a regex matching only the supported tags
+          # from build-matrix.json, allowing optional suffixes (commit shas).
+          # Example output regex: ^((3\.2|3\.3)(-.*)?|latest|keep-me)$
+          # Examples of matching tags: 3.3, 3.3-acecafe, 3.2-facedbadbeef172900000000
+          echo "supported_tags_regex=^(($(
+            <build-matrix.json jq -cr '[.version[].rubyver[:2] | join("\\.")] | join("|")'
+          ))(-.*)?|$(
+            <build-matrix.json jq -cr '[.version[].extra | select(length > 0)] | join("|")'
+          ))\$" >> $GITHUB_OUTPUT
+
+  gc_old_images:
+    name: GC old images
+    runs-on: ubuntu-latest
+    needs: read_tags
     permissions:
       packages: write
     strategy:
@@ -18,8 +40,16 @@ jobs:
           - govuk-ruby-builder
     steps:
       - uses: actions/delete-package-versions@v5
+        name: GC untagged images except 10 most recent
         with:
           package-name: ${{ matrix.pkg }}
           package-type: container
           min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
+      - uses: actions/delete-package-versions@v5
+        name: GC tagged images for no-longer-supported tags
+        with:
+          package-name: ${{ matrix.pkg }}
+          package-type: container
+          min-versions-to-keep: 10
+          ignore-versions: ${{ needs.read_tags.outputs.supported_tags_regex }}

--- a/.github/workflows/gc.yaml
+++ b/.github/workflows/gc.yaml
@@ -22,9 +22,9 @@ jobs:
           # Example output regex: ^((3\.2|3\.3)(-.*)?|latest|keep-me)$
           # Examples of matching tags: 3.3, 3.3-acecafe, 3.2-facedbadbeef172900000000
           echo "supported_tags_regex=^(($(
-            <build-matrix.json jq -cr '[.version[].rubyver[:2] | join("\\.")] | join("|")'
+            jq <build-matrix.json -cr '[.version[].rubyver[:2] | join("\\.")] | join("|")'
           ))(-.*)?|$(
-            <build-matrix.json jq -cr '[.version[].extra | select(length > 0)] | join("|")'
+            jq <build-matrix.json -cr '[.version[].extra | select(length > 0)] | join("|")'
           ))\$" >> $GITHUB_OUTPUT
 
   gc_old_images:
@@ -40,11 +40,11 @@ jobs:
           - govuk-ruby-builder
     steps:
       - uses: actions/delete-package-versions@v5
-        name: GC untagged images except 10 most recent
+        name: GC untagged images except 20 most recent
         with:
           package-name: ${{ matrix.pkg }}
           package-type: container
-          min-versions-to-keep: 10
+          min-versions-to-keep: 20  # Mostly for attestations (.att).
           delete-only-untagged-versions: 'true'
       - uses: actions/delete-package-versions@v5
         name: GC tagged images for no-longer-supported tags


### PR DESCRIPTION
Keep all images with a [supported tag](https://github.com/alphagov/govuk-ruby-images/blob/-/build-matrix.json#L2) and delete the rest except for 10 most recent unsupported-tagged images per {base, builder}.

Also keep a few more untagged packages around just so we can be sure we're not throwing away the attestations for images that haven't yet themselves been GCed. (Doesn't actually matter right now cos we're not actually doing anything with the signatures, just avoiding a potential future footshooter.)

Tested: https://github.com/alphagov/govuk-ruby-images/actions/runs/9713340782/job/26809922090#step:3:6