### PR TITLE
Consolidate linters with `github/super-linter`.

### DIFF
--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -36,9 +36,11 @@ jobs:
           show-progress: false
       - id: set-matrix
         run: |
-          echo "matrix=$(jq -c . < build-matrix.json)" >> "$GITHUB_OUTPUT"
-          echo "matrix_versions=$(jq -c .version < build-matrix.json)" >> "$GITHUB_OUTPUT"
-          echo "runs_on=$(jq -c .runs_on < build-matrix.json)" >> "$GITHUB_OUTPUT"
+          {
+            echo "matrix=$(jq -c . < build-matrix.json)"
+            echo "matrix_versions=$(jq -c .version < build-matrix.json)"
+            echo "runs_on=$(jq -c .runs_on < build-matrix.json)"
+          } >> "$GITHUB_OUTPUT"
 
   build_and_push_image:
     name: Build ruby_${{ join(matrix.version.rubyver, '.') }} for ${{ matrix.runs_on.arch }} and push to GHCR

--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -36,9 +36,9 @@ jobs:
           show-progress: false
       - id: set-matrix
         run: |
-          echo "matrix=$(jq -c . < build-matrix.json)" >> $GITHUB_OUTPUT
-          echo "matrix_versions=$(jq -c .version < build-matrix.json)" >> $GITHUB_OUTPUT
-          echo "runs_on=$(jq -c .runs_on < build-matrix.json)" >> $GITHUB_OUTPUT
+          echo "matrix=$(jq -c . < build-matrix.json)" >> "$GITHUB_OUTPUT"
+          echo "matrix_versions=$(jq -c .version < build-matrix.json)" >> "$GITHUB_OUTPUT"
+          echo "runs_on=$(jq -c .runs_on < build-matrix.json)" >> "$GITHUB_OUTPUT"
 
   build_and_push_image:
     name: Build ruby_${{ join(matrix.version.rubyver, '.') }} for ${{ matrix.runs_on.arch }} and push to GHCR
@@ -67,7 +67,7 @@ jobs:
         id: calculate-image-tags
         run: |
           CREATED_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          echo "createdDate=${CREATED_DATE}" >> $GITHUB_OUTPUT
+          echo "createdDate=${CREATED_DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Generate Base Image Metadata
         uses: docker/metadata-action@v5
@@ -190,7 +190,7 @@ jobs:
         id: calculate-image-tags
         run: |
           CREATED_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          echo "createdDate=${CREATED_DATE}" >> $GITHUB_OUTPUT
+          echo "createdDate=${CREATED_DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -224,6 +224,7 @@ jobs:
       - name: Create Manifest Lists (for Base)
         working-directory: /tmp/digests/base
         run: |
+          # shellcheck disable=SC2046
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_BASE }}/govuk-ruby-base@sha256:%s ' *)  
 
@@ -252,6 +253,7 @@ jobs:
       - name: Create Manifest Lists (for Builder)
         working-directory: /tmp/digests/builder
         run: |
+          # shellcheck disable=SC2046
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_BASE }}/govuk-ruby-builder@sha256:%s ' *)  
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,23 +1,28 @@
-name: Run linters/fixers
+---
+name: Lint
 on: [push]
+permissions: {}
 jobs:
-  shellcheck:
-    name: Shellcheck
+  superlinter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
     steps:
     - uses: actions/checkout@v4
       with:
+        fetch-depth: 0
         show-progress: false
-    - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
-  hadolint:
-    name: Hadolint
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        show-progress: false
-    - uses: jbergstroem/hadolint-gh-action@eac45b98f6d761309202bd201205a8f8c988bfad  # v1.11.0
-      with:
-        dockerfile: '**/*Dockerfile'
-        error_level: '1'  # Fail on warning or above.
+    - uses: github/super-linter@v6
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VALIDATE_BASH: true
+        VALIDATE_BASH_EXEC: true
+        VALIDATE_DOCKERFILE_HADOLINT: true
+        VALIDATE_EDITORCONFIG: true
+        VALIDATE_ENV: true
+        VALIDATE_GITHUB_ACTIONS: true
+        VALIDATE_JSON: true
+        VALIDATE_MARKDOWN: true
+        VALIDATE_YAML: true


### PR DESCRIPTION
This results in much less config and way better capability. It's slightly slower because of the image pull (not sure why it's not cached better) but it still takes under a minute so I think it's worth it since it's way easier to enable other linters in future and eliminates a lot of maintenance.

Alternatives considered:
- Keep maintaining our own glue for each linter: runs slightly faster cos no big OCI image to download, but maintenance is toily and the overall solution is brittle and inflexible (huge pain to add new linters).
- [Reviewdog](https://github.com/reviewdog/reviewdog#github-actions): similar, looks fine, but somewhat more third-party and slightly less widely used.

Neither super-linter nor Reviewdog seems to integrate with GitHub [problem matchers](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) yet, so holding off on this for now since we currently have problems matchers working (i.e. findings shown inline with code in the GitHub review UI) and they're pretty valuable.