### PR TITLE
Update to Ruby 3.3.5

### DIFF
--- a/build-matrix.json
+++ b/build-matrix.json
@@ -9,9 +9,9 @@
         },
         {
             "rubyver": [
-                "3", "3", "4"
+                "3", "3", "5"
             ],
-            "checksum": "fe6a30f97d54e029768f2ddf4923699c416cdbc3a6e96db3e2d5716c7db96a34",
+            "checksum": "3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196",
             "extra": "latest"
         }
     ],


### PR DESCRIPTION
## What?
This updates the GOV.UK Ruby Base images to Ruby 3.3.5, released 3rd September 2024.

[This update brings mainly bug fixes](https://github.com/ruby/ruby/releases/tag/v3_3_5) - no obvious CVEs this time.