### PR TITLE
Update Ruby versions to latest available

### DIFF
--- a/build-matrix.json
+++ b/build-matrix.json
@@ -2,23 +2,23 @@
     "version": [
         {
             "rubyver": [
-                "3", "2", "6"
+                "3", "2", "7"
             ],
-            "checksum": "d9cb65ecdf3f18669639f2638b63379ed6fbb17d93ae4e726d4eb2bf68a48370",
+            "checksum": "8488fa620ff0333c16d437f2b890bba3b67f8745fdecb1472568a6114aad9741",
             "extra": ""
         },
         {
             "rubyver": [
-                "3", "3", "6"
+                "3", "3", "7"
             ],
-            "checksum": "8dc48fffaf270f86f1019053f28e51e4da4cce32a36760a0603a9aee67d7fd8d",
+            "checksum": "9c37c3b12288c7aec20ca121ce76845be5bb5d77662a24919651aaf1d12c8628",
             "extra": ""
         },
         {
             "rubyver": [
-                "3", "4", "1"
+                "3", "4", "2"
             ],
-            "checksum": "3d385e5d22d368b064c817a13ed8e3cc3f71a7705d7ed1bae78013c33aa7c87f",
+            "checksum": "41328ac21f2bfdd7de6b3565ef4f0dd7543354d37e96f157a1552a6bd0eb364b",
             "extra": "latest"
         }
     ],


### PR DESCRIPTION
This updates:
- the 3.4 branch to [3.4.2]
- the 3.3 branch to [3.3.7]
- the 3.2 branch to [3.2.7]

All of these are routine/bugfix releases.

[3.4.2]: https://ruby-lang.org/en/news/2025/02/14/ruby-3-4-2-released/
[3.3.7]: https://ruby-lang.org/en/news/2025/01/15/ruby-3-3-7-released/
[3.2.7]: https://ruby-lang.org/en/news/2025/02/04/ruby-3-2-7-released/