### PR TITLE
Add Environment Shell Prompt to Ruby Containers

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -15,6 +15,14 @@ RUN echo 'gem: --no-document' >> /etc/gemrc
 
 ENV SECRET_KEY_BASE_DUMMY=1
 
+ENV GOVUK_ENVIRONMENT="development"
+
+COPY govuk_prompt.sh /etc/govuk_prompt.sh
+RUN chmod +x /etc/govuk_prompt.sh \
+    && echo '[ -f /etc/govuk_prompt.sh ] && . /etc/govuk_prompt.sh' >> /etc/bash.bashrc
+
+ENV BASH_ENV="/etc/govuk_prompt.sh"
+
 LABEL org.opencontainers.image.title="govuk-ruby-builder"
 LABEL org.opencontainers.image.authors="GOV.UK Platform Engineering"
 LABEL org.opencontainers.image.description="Builder image for GOV.UK Ruby apps"

--- a/govuk_prompt.sh
+++ b/govuk_prompt.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Set a custom shell prompt based on the GOVUK_ENVIRONMENT variable.
+# This script is sourced by login shells, like when using `kubectl exec`.
+
+# Check if we are in an interactive bash shell
+if [ -n "$BASH_VERSION" ]; then
+  case "${GOVUK_ENVIRONMENT}" in
+    "production")
+      # Red for production
+      COLOUR="\[\033[0;31m\]"
+      ;;
+    "staging")
+      # Yellow for staging
+      COLOUR="\[\033[0;33m\]"
+      ;;
+    "integration")
+      # Green for integration
+      COLOUR="\[\033[0;32m\]"
+      ;;
+    *)
+      # Blue for all other environments (development, default)
+      COLOUR="\[\033[0;36m\]"
+      ;;
+  esac
+
+  # Reset COLOUR
+  NO_COLOUR="\[\033[0m\]"
+
+  # Export the new prompt setting
+  # Format: [environment] user@hostname:working_directory$
+  export PS1="${COLOUR}[${GOVUK_ENVIRONMENT}]${NO_COLOUR} \u@\h:\w\$ "
+fi


### PR DESCRIPTION
## What?
This adds a custom PS1 Shell Prompt to our GOV.UK Ruby Base Images, to print out the environment the container is currently running in.

This may help reduce the chance of mistakes in the rare scenario that someone has exec'd straight into a pod to check or run something.