### PR TITLE
Move the Custom PS1 Prompt to the Base Image

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -148,6 +148,12 @@ RUN groupadd -g 1001 app; \
 # Set irb's history path to somewhere writable so that it doesn't complain.
 RUN echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > "$IRBRC"
 
+COPY govuk_prompt.sh /etc/govuk_prompt.sh
+RUN chmod +x /etc/govuk_prompt.sh \
+    && echo '[ -f /etc/govuk_prompt.sh ] && . /etc/govuk_prompt.sh' >> /etc/bash.bashrc
+
+ENV BASH_ENV="/etc/govuk_prompt.sh"
+
 # Crude smoke test: assert that each of the main binaries exits cleanly and
 # that the openssl gem loads.
 RUN set -x; \

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -17,12 +17,6 @@ ENV SECRET_KEY_BASE_DUMMY=1
 
 ENV GOVUK_ENVIRONMENT="development"
 
-COPY govuk_prompt.sh /etc/govuk_prompt.sh
-RUN chmod +x /etc/govuk_prompt.sh \
-    && echo '[ -f /etc/govuk_prompt.sh ] && . /etc/govuk_prompt.sh' >> /etc/bash.bashrc
-
-ENV BASH_ENV="/etc/govuk_prompt.sh"
-
 LABEL org.opencontainers.image.title="govuk-ruby-builder"
 LABEL org.opencontainers.image.authors="GOV.UK Platform Engineering"
 LABEL org.opencontainers.image.description="Builder image for GOV.UK Ruby apps"


### PR DESCRIPTION
## What?
This PR moves the Custom Shell Prompts from the Builder Image (which most apps do not use for runtime) and into the Base Image (which most apps use after their build stage).

### Related

* https://github.com/alphagov/govuk-ruby-images/pull/118