### PR TITLE
Globally pin GitHub Actions actions to commit hashes not tags

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -6,7 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           show-progress: false
       - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -31,7 +31,7 @@ jobs:
       matrix_versions: ${{ steps.set-matrix.outputs.matrix_versions }}
       runs_on: ${{ steps.set-matrix.outputs.runs_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           show-progress: false
       - id: set-matrix
@@ -52,18 +52,18 @@ jobs:
       packages: write
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           ref: ${{ inputs.gitRef || github.ref }}
           show-progress: false
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Calculate Image Tags
         id: calculate-image-tags
@@ -72,7 +72,7 @@ jobs:
           echo "createdDate=${CREATED_DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Generate Base Image Metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         id: base-image-metadata
         with:
           flavor: |
@@ -97,7 +97,7 @@ jobs:
             org.opencontainers.image.vendor=GDS
 
       - name: Generate Builder Image Metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         id: builder-image-metadata
         with:
           flavor: |
@@ -122,7 +122,7 @@ jobs:
             org.opencontainers.image.vendor=GDS
 
       - id: build-base-image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           file: base.Dockerfile
           context: .
@@ -139,7 +139,7 @@ jobs:
           cache-to: type=gha,scope=build-base-${{ matrix.version.rubyver }}-${{ matrix.runs_on.arch }},mode=max
 
       - id: build-builder-image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           file: builder.Dockerfile
           context: .
@@ -164,7 +164,7 @@ jobs:
           touch "/tmp/digests/builder/${builderDigest#sha256:}"
 
       - id: upload-digests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: digests-${{ join(matrix.version.rubyver, '.') }}-${{ matrix.runs_on.arch }}
           path: /tmp/digests/*
@@ -186,13 +186,13 @@ jobs:
       packages: write
     steps:
       - name: Download Digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: /tmp/digests
           pattern: digests-${{ join(matrix.version.rubyver, '.') }}-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Calculate Image Tags
         id: calculate-image-tags
@@ -201,14 +201,14 @@ jobs:
           echo "createdDate=${CREATED_DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate Base Image Metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         id: base-image-metadata
         with:
           flavor: |
@@ -240,7 +240,7 @@ jobs:
             $(printf '${{ env.REGISTRY_BASE }}/govuk-ruby-base@sha256:%s ' *)  
 
       - name: Generate Builder Image Metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         id: builder-image-metadata
         with:
           flavor: |

--- a/.github/workflows/gc.yaml
+++ b/.github/workflows/gc.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       supported_tags_regex: ${{ steps.get_tags.outputs.supported_tags_regex }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           show-progress: false
       - id: get_tags
@@ -39,14 +39,14 @@ jobs:
           - govuk-ruby-base
           - govuk-ruby-builder
     steps:
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         name: GC untagged images except 20 most recent
         with:
           package-name: ${{ matrix.pkg }}
           package-type: container
           min-versions-to-keep: 20  # Mostly for attestations (.att).
           delete-only-untagged-versions: 'true'
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         name: GC tagged images for no-longer-supported tags
         with:
           package-name: ${{ matrix.pkg }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       with:
         show-progress: false
     - name: Run ShellCheck
@@ -14,7 +14,7 @@ jobs:
     name: Hadolint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       with:
         show-progress: false
     - uses: jbergstroem/hadolint-gh-action@eac45b98f6d761309202bd201205a8f8c988bfad  # v1.11.0

--- a/.github/workflows/sign.yaml
+++ b/.github/workflows/sign.yaml
@@ -19,16 +19,16 @@ jobs:
       id-token: write
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: sigstore/cosign-installer@v3.4.0
+      - uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
       - uses: anchore/sbom-action/download-syft@b6a39da80722a2cb0ef5d197531764a89b5d48c3  # v0.15.8
         id: syft
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: "arn:aws:iam::172025368201:role/github_action_image_attestation"
           role-session-name: sign-govuk-ruby-images


### PR DESCRIPTION
We agree that pinning the versions of GitHub Actions actions to a commit hash
instead of a mutable tag is the correct choice.

We have a lot of places where we use them. The changes in this commit were
generated by using a tool called pinact[1] which can convert pinned tags in GHA
workflows to the commit hash they point to at that moment in time.

To generate the change set I ran `pinact run` from the root of the repository.

[1] https://github.com/suzuki-shunsuke/pinact
