### PR TITLE
Udate the aws-actions/configure-aws-credentials action

### DIFF
--- a/.github/workflows/sign.yaml
+++ b/.github/workflows/sign.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: anchore/sbom-action/download-syft@b6a39da80722a2cb0ef5d197531764a89b5d48c3  # v0.15.8
         id: syft
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
         with:
           role-to-assume: "arn:aws:iam::172025368201:role/github_action_image_attestation"
           role-session-name: sign-govuk-ruby-images


### PR DESCRIPTION
So that it uses the same version as other repositories