### PR TITLE
BAU - Remove old RubyGems

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -52,7 +52,7 @@ RUN set -x; \
     ; \
     make; \
     make install; \
-    gem update --system '3.7.2' --silent --no-document; \
+    gem update --system --silent --no-document; \
     gem pristine --extensions; \
     gem cleanup;
 


### PR DESCRIPTION
Description:
- Ruby apps always use the bundled version of Bundler. For Ruby 3.x this is Bundler 2.7.x and for Ruby 4.x this is Bundler 4.x.
- If `Gemfile.lock` has `BUNDLED WITH 4.3.1` it will still install Bundler 4.3.1
- Instead just use the latest version of RubyGems and rely on the bundled version of Bundler in Ruby