### PR TITLE
Fix broken JSON in the build matrix

### DIFF
--- a/build-matrix.json
+++ b/build-matrix.json
@@ -25,7 +25,7 @@
             "rubyver": [
                 "4", "0", "1"
             ],
-            "checksum": "3924be2d05db30f4e35f859bf028be85f4b7dd01714142fd823e4af5de2faf9d",
+            "checksum": "3924be2d05db30f4e35f859bf028be85f4b7dd01714142fd823e4af5de2faf9d"
         },
         {
             "rubyver": [


### PR DESCRIPTION
Annoyingly I broke the JSON, it's not read until after merge so no CI check failed