### PR TITLE
Remove ruby 4.0.1

### DIFF
--- a/build-matrix.json
+++ b/build-matrix.json
@@ -23,12 +23,6 @@
         },
         {
             "rubyver": [
-                "4", "0", "1"
-            ],
-            "checksum": "3924be2d05db30f4e35f859bf028be85f4b7dd01714142fd823e4af5de2faf9d"
-        },
-        {
-            "rubyver": [
                 "4", "0", "2"
             ],
             "checksum": "51502b26b50b68df4963336ca41e368cde92c928faf91654de4c4c1791f82aac",


### PR DESCRIPTION
Turns out it's not a good idea to have multiple patch versions for the same minor in our build matrix, so lets leave ruby 4.0 as 4.0.2 only