### PR TITLE
Build `release` and `govuk-replatform-test-app` images

### DIFF
--- a/.github/workflows/build-govuk-replatform-test-app.yaml
+++ b/.github/workflows/build-govuk-replatform-test-app.yaml
@@ -1,0 +1,15 @@
+name: Build arm image for govuk-replatform-test-app
+
+on:
+  pull_request:
+
+jobs:
+  build_govuk-replatform-test-app_image:
+    name: Build govuk-replatform-test-app on Ruby 3.x arm images
+    uses: alphagov/govuk-ruby-images/.github/workflows/build-app.yaml@main
+    with:
+      gitRef: ${{ github.head_ref }}
+      appName: govuk-replatform-test-app
+      rubyVersion: 3
+    permissions:
+      contents: read

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,15 @@
+name: Build arm image for release
+
+on:
+  pull_request:
+
+jobs:
+  build_release_image:
+    name: Build release on Ruby 4.x arm images
+    uses: alphagov/govuk-ruby-images/.github/workflows/build-app.yaml@main
+    with:
+      gitRef: ${{ github.head_ref }}
+      appName: release
+      rubyVersion: 4
+    permissions:
+      contents: read


### PR DESCRIPTION
Description:
- Use the `build-app` workflow to build release on latest Ruby 4.x and govuk-replatform-test-app on latest Ruby 3.x
- https://github.com/alphagov/govuk-infrastructure/issues/3961