### PR TITLE
build app jq expression requires a string

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set Ruby version
         id: set-ruby-version
         run: |
-          filtered_build_matrix=$(jq '[.version[] | select(.rubyver[0] | startswith(${{ inputs.rubyVersion }})) | {rubyver, checksum}] | last' -c < govuk-ruby-images/build-matrix.json)
+          filtered_build_matrix=$(jq '[.version[] | select(.rubyver[0] | startswith($rev)) | {rubyver, checksum}] | last' --arg rev "${{ inputs.rubyVersion }}" -c < govuk-ruby-images/build-matrix.json)
           echo "ruby_config=${filtered_build_matrix}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Docker


### PR DESCRIPTION
Description:
- `startswith(${{ inputs.rubyVersion }}))` requires a string
- https://github.com/alphagov/govuk-infrastructure/issues/3961