### PR TITLE
Unpin RubyGems from 3.7.2

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -52,7 +52,6 @@ RUN set -x; \
     ; \
     make; \
     make install; \
-    gem update --system '3.7.2' --silent --no-document; \
     gem pristine --extensions; \
     gem cleanup;
 


### PR DESCRIPTION
Description:
- We are using an old version of RubyGems which means that we are using `Bundler 2.7.2`. Ruby 4.x comes with `Bundler 4.x` so to use this we have to unpin RubyGems.
- No GOV.UK Apps that are using Ruby 4.x are using a `Gemfile.lock` that was created with `2.7.2`
- https://github.com/alphagov/govuk-infrastructure/issues/4038