### PR TITLE
BAU - Further escape script injection for `build-app` workflow

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -38,8 +38,10 @@ jobs:
 
       - name: Set Ruby version
         id: set-ruby-version
+        env:
+          RUBY_VERSION: ${{ inputs.rubyVersion }}
         run: |
-          filtered_build_matrix=$(jq '[.version[] | select(.rubyver[0] | startswith($rev)) | {rubyver, checksum}] | last' --arg rev "${{ inputs.rubyVersion }}" -c < govuk-ruby-images/build-matrix.json)
+          filtered_build_matrix=$(jq '[.version[] | select(.rubyver[0] | startswith($rev)) | {rubyver, checksum}] | last' --arg rev "$RUBY_VERSION" -c < govuk-ruby-images/build-matrix.json)
           echo "ruby_config=${filtered_build_matrix}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Docker


### PR DESCRIPTION
Description:
- `--arg rev` escapes the input provided but it doesn't hurt to further escape it by storing `${{ inputs.rubyVersion }}` as an environment variable as per the [GDS Way](https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/using-github-actions.html#script-injections-interpolating-untrusted-user-content)