### PR TITLE
Add ruby 4.0 to sign images workflow

### DIFF
--- a/.github/workflows/sign.yaml
+++ b/.github/workflows/sign.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['3.2', '3.3', '3.4']
+        version: ['3.2', '3.3', '3.4', '4.0']
     permissions:
       packages: write
       id-token: write


### PR DESCRIPTION
We've not been signing ruby 4.0 images