### PR TITLE
Bump Ruby 4.0.3 to 4.0.5

### DIFF
--- a/build-matrix.json
+++ b/build-matrix.json
@@ -23,9 +23,9 @@
         },
         {
             "rubyver": [
-                "4", "0", "3"
+                "4", "0", "5"
             ],
-            "checksum": "77964acc370d5c8375b9502e5ba6c13c03ef91ab9eb9f521c84fb42b9c9a6b0f",
+            "checksum": "7d6149079a63f8ae1d326c9fa65c6019ba2dc3155eae7b39159817911c88958e",
             "extra": "latest"
         }
     ],


### PR DESCRIPTION
## What?
This upgrades our Base images from Ruby 4.0.3 to 4.0.5 as the now latest version.