### PR TITLE
 Discontinue x86 Builds for Base Images

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -140,8 +140,7 @@ jobs:
           provenance: false
           sbom: false
           build-args: |
-            REPOSITORY=${{ env.REGISTRY_BASE }}
-            BASE_IMAGE_DIGEST=${{steps.build-base-image.outputs.digest }}
+            BASE_IMAGE_REF=${{ env.REGISTRY_BASE }}/${{ env.REGISTRY_OWNER }}/govuk-ruby-base@${{ steps.build-base-image.outputs.digest }}
             OWNER=${{ github.repository_owner }}
           labels: ${{ steps.builder-image-metadata.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_BASE }}/${{ env.REGISTRY_OWNER }}/govuk-ruby-builder,push-by-digest=true,name-canonical=true,push=true
@@ -181,8 +180,7 @@ jobs:
           provenance: false
           sbom: false
           build-args: |
-            REPOSITORY=${{ env.REGISTRY_BASE }}
-            BASE_IMAGE_DIGEST=${{steps.build-base-image.outputs.digest }}
+            BASE_IMAGE_REF=${{ env.REGISTRY_BASE }}/${{ env.REGISTRY_OWNER }}/govuk-ruby-base@${{ steps.build-base-image.outputs.digest }}
             OWNER=${{ github.repository_owner }}
           tags: ${{ steps.builder-image-metadata.outputs.tags }}
           labels: ${{ steps.builder-image-metadata.outputs.labels }}

--- a/.github/workflows/build-govuk-replatform-test-app.yaml
+++ b/.github/workflows/build-govuk-replatform-test-app.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build_govuk-replatform-test-app_image:
     name: Build govuk-replatform-test-app on Ruby 3.x arm images
-    uses: alphagov/govuk-ruby-images/.github/workflows/build-app.yaml@main
+    uses: ./.github/workflows/build-app.yaml
     with:
       gitRef: ${{ github.head_ref }}
       appName: govuk-replatform-test-app

--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -13,16 +13,6 @@ on:
         required: true
         type: boolean
         default: true
-  push:
-    branches:
-      - main
-    paths:
-      - "**.Dockerfile"
-      - "build-matrix.json"
-      - "*.sh"
-      - ".github/workflows/build-multiarch.yaml"
-  schedule:
-    - cron: "34 3 * * *"
 
 env:
   REGISTRY_BASE: ghcr.io/alphagov

--- a/.github/workflows/build-multiarch.yaml
+++ b/.github/workflows/build-multiarch.yaml
@@ -21,6 +21,8 @@ jobs:
   configure_builds:
     name: Read configuration from build-matrix.json
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       matrix_versions: ${{ steps.set-matrix.outputs.matrix_versions }}
@@ -45,6 +47,7 @@ jobs:
       matrix: ${{ fromJson(needs.configure_builds.outputs.matrix) }}
     runs-on: ${{ matrix.runs_on.runner_type }}
     permissions:
+      contents: read
       packages: write
     steps:
       - name: Login to GHCR
@@ -158,7 +161,7 @@ jobs:
           provenance: false
           sbom: false
           build-args: |
-            BASE_IMAGE_DIGEST=${{steps.build-base-image.outputs.digest }}
+            BASE_IMAGE_REF=${{ env.REGISTRY_BASE }}/govuk-ruby-base@${{ steps.build-base-image.outputs.digest }}
             OWNER=${{ github.repository_owner }}
           labels: ${{ steps.builder-image-metadata.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_BASE }}/govuk-ruby-builder,push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/build-push-arm-image.yml
+++ b/.github/workflows/build-push-arm-image.yml
@@ -56,7 +56,6 @@ concurrency:
 
 env:
   IMAGE_PLATFORM: linux/arm64
-  REGISTRY_BASE: ghcr.io/${{ github.repository_owner }}
 
 jobs:
   configure_builds:
@@ -90,8 +89,8 @@ jobs:
       PUSH_TO_REGISTRY: ${{ github.event_name != 'workflow_dispatch' || inputs.pushToRegistry }}
       RUBY_MAJOR: ${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}
       RUBY_VERSION: ${{ join(matrix.version.rubyver, '.') }}
-      BASE_IMAGE_NAME: ${{ env.REGISTRY_BASE }}/govuk-ruby-base
-      BUILDER_IMAGE_NAME: ${{ env.REGISTRY_BASE }}/govuk-ruby-builder
+      BASE_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/govuk-ruby-base
+      BUILDER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/govuk-ruby-builder
     steps:
       - uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
         with:

--- a/.github/workflows/build-push-arm-image.yml
+++ b/.github/workflows/build-push-arm-image.yml
@@ -2,13 +2,18 @@ name: Build and push ARM images
 run-name: Build and push ARM images @ ${{ inputs.gitRef || github.sha }}
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       gitRef:
         description: Git ref, tag, or SHA to checkout before building.
-        required: false
+        required: true
         type: string
-        default: ${{ github.sha }}
+        default: main
+      pushToRegistry:
+        description: Push to image registry. Set to false to build without pushing.
+        required: true
+        type: boolean
+        default: true
       runnerName:
         description: Runner label used for native ARM64 builds.
         required: false
@@ -34,6 +39,16 @@ on:
         required: false
         type: boolean
         default: true
+  push:
+    branches:
+      - main
+    paths:
+      - "**.Dockerfile"
+      - "build-matrix.json"
+      - "*.sh"
+      - ".github/workflows/build-push-arm-image.yml"
+  schedule:
+    - cron: "34 3 * * *"
 
 concurrency:
   group: build-push-arm-image-${{ github.repository }}
@@ -52,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.gitRef }}
+          ref: ${{ inputs.gitRef || github.ref }}
           fetch-depth: 1
           show-progress: false
 
@@ -62,7 +77,7 @@ jobs:
   build_and_push_images:
     name: Build ruby_${{ join(matrix.version.rubyver, '.') }} ARM images
     needs: configure_builds
-    runs-on: ${{ inputs.runnerName }}
+    runs-on: ${{ inputs.runnerName || 'ubuntu-24.04-arm' }}
     timeout-minutes: 30
     strategy:
       matrix:
@@ -72,6 +87,7 @@ jobs:
       id-token: write
       packages: write
     env:
+      PUSH_TO_REGISTRY: ${{ github.event_name != 'workflow_dispatch' || inputs.pushToRegistry }}
       RUBY_MAJOR: ${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}
       RUBY_VERSION: ${{ join(matrix.version.rubyver, '.') }}
       BASE_IMAGE_NAME: ${{ env.REGISTRY_BASE }}/govuk-ruby-base
@@ -83,11 +99,12 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.gitRef }}
+          ref: ${{ inputs.gitRef || github.ref }}
           fetch-depth: 1
           show-progress: false
 
       - name: Login to GHCR
+        if: ${{ env.PUSH_TO_REGISTRY == 'true' }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
@@ -114,6 +131,12 @@ jobs:
       - name: Output created date
         id: calculate-created-date
         run: echo "createdDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Set local image refs
+        id: local-image-refs
+        run: |
+          echo "base=govuk-ruby-base:arm-${RUBY_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "builder=govuk-ruby-builder:arm-${RUBY_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Generate base image metadata
         id: base-image-metadata
@@ -145,10 +168,11 @@ jobs:
             type=raw,priority=100,value=${{ env.RUBY_VERSION }}-${{ steps.local-head.outputs.sha }}
 
       - name: Install Cosign
-        if: ${{ inputs.signImage }}
+        if: ${{ env.PUSH_TO_REGISTRY == 'true' && (github.event_name != 'workflow_dispatch' || inputs.signImage) }}
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
 
       - name: Build and push base image
+        if: ${{ env.PUSH_TO_REGISTRY == 'true' }}
         id: build-base-image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -166,11 +190,32 @@ jobs:
           annotations: ${{ steps.base-image-metadata.outputs.annotations }}
           cache-from: type=gha,scope=build-base-${{ env.RUBY_VERSION }}-arm64
           cache-to: type=gha,mode=max,scope=build-base-${{ env.RUBY_VERSION }}-arm64
-          provenance: ${{ inputs.generateProvenance }}
-          sbom: ${{ inputs.generateSbom }}
+          provenance: ${{ github.event_name != 'workflow_dispatch' || inputs.generateProvenance }}
+          sbom: ${{ github.event_name != 'workflow_dispatch' || inputs.generateSbom }}
+
+      - name: Build base image locally
+        if: ${{ env.PUSH_TO_REGISTRY != 'true' }}
+        id: build-base-image-local
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: base.Dockerfile
+          build-args: |
+            RUBY_MAJOR=${{ env.RUBY_MAJOR }}
+            RUBY_VERSION=${{ env.RUBY_VERSION }}
+            RUBY_CHECKSUM=${{ matrix.version.checksum }}
+          pull: true
+          load: true
+          platforms: ${{ env.IMAGE_PLATFORM }}
+          tags: ${{ steps.local-image-refs.outputs.base }}
+          labels: ${{ steps.base-image-metadata.outputs.labels }}
+          cache-from: type=gha,scope=build-base-${{ env.RUBY_VERSION }}-arm64
+          cache-to: type=gha,mode=max,scope=build-base-${{ env.RUBY_VERSION }}-arm64
+          provenance: false
+          sbom: false
 
       - name: Sign base image
-        if: ${{ inputs.signImage }}
+        if: ${{ env.PUSH_TO_REGISTRY == 'true' && (github.event_name != 'workflow_dispatch' || inputs.signImage) }}
         env:
           DIGEST: ${{ steps.build-base-image.outputs.digest }}
         run: cosign sign --recursive --yes "${BASE_IMAGE_NAME}@${DIGEST}"
@@ -205,15 +250,15 @@ jobs:
             type=raw,priority=100,value=${{ env.RUBY_VERSION }}-${{ steps.local-head.outputs.sha }}
 
       - name: Build and push builder image
+        if: ${{ env.PUSH_TO_REGISTRY == 'true' }}
         id: build-builder-image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: builder.Dockerfile
           build-args: |
-            REPOSITORY=ghcr.io
             OWNER=${{ github.repository_owner }}
-            BASE_IMAGE_DIGEST=${{ steps.build-base-image.outputs.digest }}
+            BASE_IMAGE_REF=${{ env.BASE_IMAGE_NAME }}@${{ steps.build-base-image.outputs.digest }}
           pull: true
           push: true
           platforms: ${{ env.IMAGE_PLATFORM }}
@@ -222,17 +267,37 @@ jobs:
           annotations: ${{ steps.builder-image-metadata.outputs.annotations }}
           cache-from: type=gha,scope=build-builder-${{ env.RUBY_VERSION }}-arm64
           cache-to: type=gha,mode=max,scope=build-builder-${{ env.RUBY_VERSION }}-arm64
-          provenance: ${{ inputs.generateProvenance }}
-          sbom: ${{ inputs.generateSbom }}
+          provenance: ${{ github.event_name != 'workflow_dispatch' || inputs.generateProvenance }}
+          sbom: ${{ github.event_name != 'workflow_dispatch' || inputs.generateSbom }}
+
+      - name: Build builder image locally
+        if: ${{ env.PUSH_TO_REGISTRY != 'true' }}
+        id: build-builder-image-local
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: builder.Dockerfile
+          build-args: |
+            OWNER=${{ github.repository_owner }}
+            BASE_IMAGE_REF=${{ steps.local-image-refs.outputs.base }}
+          pull: false
+          load: true
+          platforms: ${{ env.IMAGE_PLATFORM }}
+          tags: ${{ steps.local-image-refs.outputs.builder }}
+          labels: ${{ steps.builder-image-metadata.outputs.labels }}
+          cache-from: type=gha,scope=build-builder-${{ env.RUBY_VERSION }}-arm64
+          cache-to: type=gha,mode=max,scope=build-builder-${{ env.RUBY_VERSION }}-arm64
+          provenance: false
+          sbom: false
 
       - name: Sign builder image
-        if: ${{ inputs.signImage }}
+        if: ${{ env.PUSH_TO_REGISTRY == 'true' && (github.event_name != 'workflow_dispatch' || inputs.signImage) }}
         env:
           DIGEST: ${{ steps.build-builder-image.outputs.digest }}
         run: cosign sign --recursive --yes "${BUILDER_IMAGE_NAME}@${DIGEST}"
 
-      - name: Write build summary
-        if: ${{ inputs.writeSummary }}
+      - name: Write push build summary
+        if: ${{ env.PUSH_TO_REGISTRY == 'true' && (github.event_name != 'workflow_dispatch' || inputs.writeSummary) }}
         env:
           BASE_DIGEST: ${{ steps.build-base-image.outputs.digest }}
           BUILDER_DIGEST: ${{ steps.build-builder-image.outputs.digest }}
@@ -241,9 +306,25 @@ jobs:
             echo '### Ruby image build'
             echo
             echo "- Ruby version: \`${RUBY_VERSION}\`"
-            echo "- Git ref: \`${{ inputs.gitRef }}\`"
+            echo "- Git ref: \`${{ inputs.gitRef || github.ref }}\`"
             echo "- Platform: \`${IMAGE_PLATFORM}\`"
+            echo "- Pushed to registry: \`true\`"
             echo "- Base image: \`${BASE_IMAGE_NAME}\` @ \`${BASE_DIGEST}\`"
             echo "- Builder image: \`${BUILDER_IMAGE_NAME}\` @ \`${BUILDER_DIGEST}\`"
-            echo "- Signed with Cosign: \`${{ inputs.signImage }}\`"
+            echo "- Signed with Cosign: \`${{ github.event_name != 'workflow_dispatch' || inputs.signImage }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Write local build summary
+        if: ${{ env.PUSH_TO_REGISTRY != 'true' && (github.event_name != 'workflow_dispatch' || inputs.writeSummary) }}
+        run: |
+          {
+            echo '### Ruby image build'
+            echo
+            echo "- Ruby version: \`${RUBY_VERSION}\`"
+            echo "- Git ref: \`${{ inputs.gitRef || github.ref }}\`"
+            echo "- Platform: \`${IMAGE_PLATFORM}\`"
+            echo "- Pushed to registry: \`false\`"
+            echo "- Base image: \`${{ steps.local-image-refs.outputs.base }}\`"
+            echo "- Builder image: \`${{ steps.local-image-refs.outputs.builder }}\`"
+            echo '- Provenance/SBOM/signing skipped for local-only builds'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-push-arm-image.yml
+++ b/.github/workflows/build-push-arm-image.yml
@@ -61,6 +61,8 @@ jobs:
   configure_builds:
     name: Read configuration from build-matrix.json
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix_versions: ${{ steps.set-matrix.outputs.matrix_versions }}
     steps:

--- a/.github/workflows/build-push-arm-image.yml
+++ b/.github/workflows/build-push-arm-image.yml
@@ -1,0 +1,249 @@
+name: Build and push ARM images
+run-name: Build and push ARM images @ ${{ inputs.gitRef || github.sha }}
+
+on:
+  workflow_call:
+    inputs:
+      gitRef:
+        description: Git ref, tag, or SHA to checkout before building.
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      runnerName:
+        description: Runner label used for native ARM64 builds.
+        required: false
+        type: string
+        default: ubuntu-24.04-arm
+      generateProvenance:
+        description: Generate OCI provenance attestation during image build.
+        required: false
+        type: boolean
+        default: true
+      generateSbom:
+        description: Generate OCI SBOM attestation during image build.
+        required: false
+        type: boolean
+        default: true
+      signImage:
+        description: Sign pushed image digests and attached attestations with Cosign using GitHub OIDC.
+        required: false
+        type: boolean
+        default: true
+      writeSummary:
+        description: Write image details to GitHub step summary.
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: build-push-arm-image-${{ github.repository }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_PLATFORM: linux/arm64
+  REGISTRY_BASE: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  configure_builds:
+    name: Read configuration from build-matrix.json
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_versions: ${{ steps.set-matrix.outputs.matrix_versions }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.gitRef }}
+          fetch-depth: 1
+          show-progress: false
+
+      - id: set-matrix
+        run: echo "matrix_versions=$(jq -c .version < build-matrix.json)" >> "$GITHUB_OUTPUT"
+
+  build_and_push_images:
+    name: Build ruby_${{ join(matrix.version.rubyver, '.') }} ARM images
+    needs: configure_builds
+    runs-on: ${{ inputs.runnerName }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        version: ${{ fromJson(needs.configure_builds.outputs.matrix_versions) }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    env:
+      RUBY_MAJOR: ${{ matrix.version.rubyver[0] }}.${{ matrix.version.rubyver[1] }}
+      RUBY_VERSION: ${{ join(matrix.version.rubyver, '.') }}
+      BASE_IMAGE_NAME: ${{ env.REGISTRY_BASE }}/govuk-ruby-base
+      BUILDER_IMAGE_NAME: ${{ env.REGISTRY_BASE }}/govuk-ruby-builder
+    steps:
+      - uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
+        with:
+          version: version=29.7.1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.gitRef }}
+          fetch-depth: 1
+          show-progress: false
+
+      - name: Login to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          platforms: ${{ env.IMAGE_PLATFORM }}
+
+      - name: Resolve checked out SHA
+        id: local-head
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Output created date
+        id: calculate-created-date
+        run: echo "createdDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Generate base image metadata
+        id: base-image-metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          flavor: |
+            latest=false
+          images: |
+            ${{ env.BASE_IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.title=govuk-ruby-base
+            org.opencontainers.image.authors="GOV.UK Platform Engineering"
+            org.opencontainers.image.description="Base image for GOV.UK Ruby apps"
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.local-head.outputs.sha }}
+            org.opencontainers.image.version=${{ env.RUBY_VERSION }}
+            org.opencontainers.image.created=${{ steps.calculate-created-date.outputs.createdDate }}
+            org.opencontainers.image.vendor=GDS
+          annotations: |
+            org.opencontainers.image.authors="Government Digital Service"
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ env.RUBY_MAJOR }}
+            type=raw,value=${{ env.RUBY_VERSION }}
+            type=raw,value=latest,enable=${{ matrix.version.extra == 'latest' }}
+            type=raw,priority=500,value=${{ env.RUBY_MAJOR }}-${{ steps.local-head.outputs.short_sha }}
+            type=raw,priority=400,value=${{ env.RUBY_VERSION }}-${{ steps.local-head.outputs.short_sha }}
+            type=raw,priority=200,value=${{ env.RUBY_MAJOR }}-${{ steps.local-head.outputs.sha }}
+            type=raw,priority=100,value=${{ env.RUBY_VERSION }}-${{ steps.local-head.outputs.sha }}
+
+      - name: Install Cosign
+        if: ${{ inputs.signImage }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+
+      - name: Build and push base image
+        id: build-base-image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: base.Dockerfile
+          build-args: |
+            RUBY_MAJOR=${{ env.RUBY_MAJOR }}
+            RUBY_VERSION=${{ env.RUBY_VERSION }}
+            RUBY_CHECKSUM=${{ matrix.version.checksum }}
+          pull: true
+          push: true
+          platforms: ${{ env.IMAGE_PLATFORM }}
+          tags: ${{ steps.base-image-metadata.outputs.tags }}
+          labels: ${{ steps.base-image-metadata.outputs.labels }}
+          annotations: ${{ steps.base-image-metadata.outputs.annotations }}
+          cache-from: type=gha,scope=build-base-${{ env.RUBY_VERSION }}-arm64
+          cache-to: type=gha,mode=max,scope=build-base-${{ env.RUBY_VERSION }}-arm64
+          provenance: ${{ inputs.generateProvenance }}
+          sbom: ${{ inputs.generateSbom }}
+
+      - name: Sign base image
+        if: ${{ inputs.signImage }}
+        env:
+          DIGEST: ${{ steps.build-base-image.outputs.digest }}
+        run: cosign sign --recursive --yes "${BASE_IMAGE_NAME}@${DIGEST}"
+
+      - name: Generate builder image metadata
+        id: builder-image-metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          flavor: |
+            latest=false
+          images: |
+            ${{ env.BUILDER_IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.title=govuk-ruby-builder
+            org.opencontainers.image.authors="GOV.UK Platform Engineering"
+            org.opencontainers.image.description="Builder image for GOV.UK Ruby apps"
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.local-head.outputs.sha }}
+            org.opencontainers.image.version=${{ env.RUBY_VERSION }}
+            org.opencontainers.image.created=${{ steps.calculate-created-date.outputs.createdDate }}
+            org.opencontainers.image.vendor=GDS
+          annotations: |
+            org.opencontainers.image.authors="Government Digital Service"
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ env.RUBY_MAJOR }}
+            type=raw,value=${{ env.RUBY_VERSION }}
+            type=raw,value=latest,enable=${{ matrix.version.extra == 'latest' }}
+            type=raw,priority=500,value=${{ env.RUBY_MAJOR }}-${{ steps.local-head.outputs.short_sha }}
+            type=raw,priority=400,value=${{ env.RUBY_VERSION }}-${{ steps.local-head.outputs.short_sha }}
+            type=raw,priority=200,value=${{ env.RUBY_MAJOR }}-${{ steps.local-head.outputs.sha }}
+            type=raw,priority=100,value=${{ env.RUBY_VERSION }}-${{ steps.local-head.outputs.sha }}
+
+      - name: Build and push builder image
+        id: build-builder-image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: builder.Dockerfile
+          build-args: |
+            REPOSITORY=ghcr.io
+            OWNER=${{ github.repository_owner }}
+            BASE_IMAGE_DIGEST=${{ steps.build-base-image.outputs.digest }}
+          pull: true
+          push: true
+          platforms: ${{ env.IMAGE_PLATFORM }}
+          tags: ${{ steps.builder-image-metadata.outputs.tags }}
+          labels: ${{ steps.builder-image-metadata.outputs.labels }}
+          annotations: ${{ steps.builder-image-metadata.outputs.annotations }}
+          cache-from: type=gha,scope=build-builder-${{ env.RUBY_VERSION }}-arm64
+          cache-to: type=gha,mode=max,scope=build-builder-${{ env.RUBY_VERSION }}-arm64
+          provenance: ${{ inputs.generateProvenance }}
+          sbom: ${{ inputs.generateSbom }}
+
+      - name: Sign builder image
+        if: ${{ inputs.signImage }}
+        env:
+          DIGEST: ${{ steps.build-builder-image.outputs.digest }}
+        run: cosign sign --recursive --yes "${BUILDER_IMAGE_NAME}@${DIGEST}"
+
+      - name: Write build summary
+        if: ${{ inputs.writeSummary }}
+        env:
+          BASE_DIGEST: ${{ steps.build-base-image.outputs.digest }}
+          BUILDER_DIGEST: ${{ steps.build-builder-image.outputs.digest }}
+        run: |
+          {
+            echo '### Ruby image build'
+            echo
+            echo "- Ruby version: \`${RUBY_VERSION}\`"
+            echo "- Git ref: \`${{ inputs.gitRef }}\`"
+            echo "- Platform: \`${IMAGE_PLATFORM}\`"
+            echo "- Base image: \`${BASE_IMAGE_NAME}\` @ \`${BASE_DIGEST}\`"
+            echo "- Builder image: \`${BUILDER_IMAGE_NAME}\` @ \`${BUILDER_DIGEST}\`"
+            echo "- Signed with Cosign: \`${{ inputs.signImage }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build_release_image:
     name: Build release on Ruby 4.x arm images
-    uses: alphagov/govuk-ruby-images/.github/workflows/build-app.yaml@main
+    uses: ./.github/workflows/build-app.yaml
     with:
       gitRef: ${{ github.head_ref }}
       appName: release

--- a/.github/workflows/sign.yaml
+++ b/.github/workflows/sign.yaml
@@ -2,13 +2,14 @@ name: Sign container images
 
 on:
   workflow_run:
-    workflows: ["Build and push multi-arch images"]
+    workflows: ["Build and push ARM images"]
     types:
       - completed
   workflow_dispatch:
 
 jobs:
   sign:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     name: Create attestation
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use the two images in your app's Dockerfile.
 Specify the image tag that corresponds to the `<major>.<minor>` Ruby version that your application needs.
 
 ```dockerfile
-ARG ruby_version=3.3
+ARG ruby_version=4.0
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
@@ -111,13 +111,14 @@ Ensure that [govuk-replatform-test-app](https://github.com/alphagov/govuk-replat
 
 ### Build workflow maintenance
 
-The build workflow (`.github/workflows/build-multiarch.yaml`) includes several features to ensure reliable image builds:
+The ARM image build workflow (`.github/workflows/build-push-arm-image.yml`), triggered by `.github/workflows/build-multiarch.yaml`, includes several features to ensure reliable image builds:
 
-- **Dependency chain**: Manifest combination and garbage collection only run after successful builds, preventing deletion of working images when new builds fail
+- **Native ARM builds**: Images are built on GitHub ARM runners, so no manifest-combining job is needed
+- **Docker 29**: Builds use a current Docker engine and Buildx setup
 - **Path filtering**: Builds are skipped when only non-Docker files change (e.g., documentation updates), reducing unnecessary CI/CD resource usage
 - **Failure notifications**: Failed builds automatically notify `#govuk-platform-support` via Slack
-- **Manual control**: Workflow can be dispatched manually with option to skip registry push for testing
-- **Multi-architecture**: Builds images for multiple Ruby versions across amd64 and arm64 architectures in parallel
+- **Manual triggering**: Workflow can still be dispatched manually for a chosen ref
+- **Supply chain metadata**: Builds publish provenance, SBOM attestations, and Cosign signatures
 
 The build app workflow (`.github/workflows/build-app.yaml`) ensures that changes to `base.Dockerfile` and `builder.Dockerfile` are 
 tested against `release` (Ruby 4.x) and `govuk-replatform-test-app` (Ruby 3.3.x) to ensure this doesn't break the CI/CD pipeline.

--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ Ensure that [govuk-replatform-test-app](https://github.com/alphagov/govuk-replat
 
 ### Build workflow maintenance
 
-The ARM image build workflow (`.github/workflows/build-push-arm-image.yml`), triggered by `.github/workflows/build-multiarch.yaml`, includes several features to ensure reliable image builds:
+The ARM image build workflow (`.github/workflows/build-push-arm-image.yml`), triggered directly by manual dispatch, scheduled runs, and pushes to `main`, includes several features to ensure reliable image builds:
 
 - **Native ARM builds**: Images are built on GitHub ARM runners, so no manifest-combining job is needed
 - **Docker 29**: Builds use a current Docker engine and Buildx setup
 - **Path filtering**: Builds are skipped when only non-Docker files change (e.g., documentation updates), reducing unnecessary CI/CD resource usage
 - **Failure notifications**: Failed builds automatically notify `#govuk-platform-support` via Slack
-- **Manual triggering**: Workflow can still be dispatched manually for a chosen ref
+- **Manual triggering**: Workflow can be dispatched manually for a chosen ref, with optional local-only builds that skip registry push
 - **Supply chain metadata**: Builds publish provenance, SBOM attestations, and Cosign signatures
 
 The build app workflow (`.github/workflows/build-app.yaml`) ensures that changes to `base.Dockerfile` and `builder.Dockerfile` are 

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,7 +1,8 @@
-ARG REPOSITORY=ghcr.io
+ARG BASE_IMAGE_REF
 ARG OWNER=alphagov
-ARG BASE_IMAGE_DIGEST
-FROM ${REPOSITORY}/${OWNER}/govuk-ruby-base@${BASE_IMAGE_DIGEST}
+FROM ${BASE_IMAGE_REF}
+
+ARG OWNER
 
 RUN install_packages \
     g++ git gpg libc-dev libcurl4-openssl-dev libgdbm-dev libssl-dev \


### PR DESCRIPTION
## What?
This retires x86 builds of our Ruby Base Images, resulting in only ARM builds. I haven't deleted the old workflow, instead removing the workflow triggers so the ARM-only Workflow becomes the default.